### PR TITLE
NGC-2682 Enable mobile help to save in application.conf, not service-manager-config

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -175,9 +175,9 @@ microservice {
 }
 
 helpToSave {
-  enabled = false
+  enabled = true
   infoUrl = "https://www.gov.uk/government/publications/help-to-save-what-it-is-and-who-its-for/the-help-to-save-scheme"
   invitationUrl = "http://localhost:7000/help-to-save"
   accessAccountUrl = "http://localhost:7000/help-to-save/access-account"
-  dailyInvitationCap = 0
+  dailyInvitationCap = 2147483647
 }


### PR DESCRIPTION
...and disable it in app-config-base.

This means it's always enabled when running locally (either from sm or sbt) and is always disabled when running in the server environments, unless the app-config-base settings are overridden in app-config-{qa,staging,production}.