### PR TITLE
NGC-3052 Allow spaces to be specified in title & message in app-config-*

### DIFF
--- a/app/uk/gov/hmrc/mobilehelptosave/config/Base64.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/config/Base64.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.mobilehelptosave.config
+
+import java.nio.charset.StandardCharsets
+
+object Base64 {
+  private val decoder = java.util.Base64.getDecoder
+
+  def decode(encoded: String): String = new String(decoder.decode(encoded), StandardCharsets.UTF_8)
+}

--- a/app/uk/gov/hmrc/mobilehelptosave/config/GuiceModule.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/config/GuiceModule.scala
@@ -34,8 +34,8 @@ class GuiceModule(environment: Environment, configuration: Configuration) extend
 
   override def configure(): Unit = {
     bindConfigBoolean("helpToSave.shuttering.shuttered")
-    bindConfigString("helpToSave.shuttering.title")
-    bindConfigString("helpToSave.shuttering.message")
+    bindConfigBase64String("helpToSave.shuttering.title")
+    bindConfigBase64String("helpToSave.shuttering.message")
     bindConfigBoolean("helpToSave.enabled")
     bindConfigBoolean("helpToSave.balanceEnabled")
     bindConfigBoolean("helpToSave.paidInThisMonthEnabled")
@@ -68,6 +68,12 @@ class GuiceModule(environment: Environment, configuration: Configuration) extend
 
   private def bindConfigString(path: String): Unit = {
     bindConstant().annotatedWith(named(path)).to(configuration.underlying.getString(path))
+  }
+
+  private def bindConfigBase64String(path: String): Unit = {
+    val encoded = configuration.underlying.getString(path)
+    val decoded = Base64.decode(encoded)
+    bindConstant().annotatedWith(named(path)).to(decoded)
   }
 
   private def bindBaseUrl(serviceName: String) =

--- a/it/uk/gov/hmrc/mobilehelptosave/StartupConfigISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/StartupConfigISpec.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.mobilehelptosave
 
+import java.util.Base64
+
 import org.scalatestplus.play.{PortNumber, WsScalaTestClient}
 import play.api.Application
 import play.api.libs.json.{JsObject, Json}
@@ -38,6 +40,7 @@ class StartupConfigISpec extends UnitSpec with WsScalaTestClient with WireMockSu
   private val internalAuthId = InternalAuthId("test-internal-auth-id")
   private val generator = new Generator(0)
   private val nino = generator.nextNino
+  private val base64Encoder = Base64.getEncoder
 
   "GET /mobile-help-to-save/startup" should {
     "return enabled=true when configuration value helpToSave.enabled=true" in withTestServerAndInvitationCleanup(
@@ -79,8 +82,8 @@ class StartupConfigISpec extends UnitSpec with WsScalaTestClient with WireMockSu
       wireMockApplicationBuilder()
         .configure(
           "helpToSave.shuttering.shuttered" -> true,
-          "helpToSave.shuttering.title" -> "Shuttered",
-          "helpToSave.shuttering.message" -> "HTS is currently not available",
+          "helpToSave.shuttering.title" -> base64Encode("Shuttered"),
+          "helpToSave.shuttering.message" -> base64Encode("HTS is currently not available"),
           "helpToSave.enabled" -> true,
           "helpToSave.savingRemindersEnabled" -> true
         )
@@ -173,6 +176,10 @@ class StartupConfigISpec extends UnitSpec with WsScalaTestClient with WireMockSu
       (response.json \ "user" \ "state").asOpt[String] shouldBe Some("InvitedFirstTime")
     }
 
+  }
+
+  private def base64Encode(s: String): String = {
+    base64Encoder.encodeToString(s.getBytes("UTF-8"))
   }
 
   private def withTestServerAndInvitationCleanup[R](app: Application)(testCode: (Application, PortNumber) => R): R =

--- a/test/uk/gov/hmrc/mobilehelptosave/config/Base64Spec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/config/Base64Spec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.mobilehelptosave.config
+
+import org.scalatest.{Matchers, WordSpec}
+
+class Base64Spec extends WordSpec with Matchers {
+  "decode" should {
+    "decode simple values" in {
+      Base64.decode("YXNkZg==") shouldBe "asdf"
+    }
+
+    "decode non-ASCII characters using UTF-8 encoding" in {
+      Base64.decode("4oCcc21hcnQgcXVvdGVz4oCd") shouldBe "\u201csmart quotes\u201d"
+    }
+
+    "decode empty value to empty string" in {
+      Base64.decode("") shouldBe ""
+    }
+  }
+}


### PR DESCRIPTION
The deployment tooling does not allow spaces in config properties so to work around this we base64 encode these config properties.