### PR TITLE
[NGC-3168][FD] Use collections with test name suffix for all integration tests

### DIFF
--- a/it/uk/gov/hmrc/mobilehelptosave/InvitationNoFilterISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/InvitationNoFilterISpec.scala
@@ -24,15 +24,15 @@ import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
 import uk.gov.hmrc.domain.Generator
 import uk.gov.hmrc.mobilehelptosave.services.{Clock, FixedFakeClock}
 import uk.gov.hmrc.mobilehelptosave.stubs.{AuthStub, HelpToSaveStub}
-import uk.gov.hmrc.mobilehelptosave.support.{OneServerPerSuiteWsClient, WireMockSupport}
+import uk.gov.hmrc.mobilehelptosave.support.{MongoTestCollectionsDropAfterAll, OneServerPerSuiteWsClient, WireMockSupport}
 
 class InvitationNoFilterISpec extends WordSpec with Matchers
   with FutureAwaits with DefaultAwaitTimeout with InvitationCleanup
-  with WireMockSupport with OneServerPerSuiteWsClient {
+  with WireMockSupport with MongoTestCollectionsDropAfterAll with OneServerPerSuiteWsClient {
 
   private val fixedClock = new FixedFakeClock(DateTime.parse("2018-02-08T12:34:56.000Z"))
 
-  override implicit lazy val app: Application = wireMockApplicationBuilder()
+  override implicit lazy val app: Application = appBuilder
     .configure(
       InvitationConfig.Enabled,
       "helpToSave.invitationFilters.survey" -> "false",

--- a/it/uk/gov/hmrc/mobilehelptosave/InvitationSurveyAndWorkingTaxCreditsFilterISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/InvitationSurveyAndWorkingTaxCreditsFilterISpec.scala
@@ -8,15 +8,15 @@ import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
 import uk.gov.hmrc.domain.Generator
 import uk.gov.hmrc.mobilehelptosave.services.{Clock, FixedFakeClock}
 import uk.gov.hmrc.mobilehelptosave.stubs.{AuthStub, HelpToSaveStub, NativeAppWidgetStub, TaxCreditBrokerStub}
-import uk.gov.hmrc.mobilehelptosave.support.{OneServerPerSuiteWsClient, WireMockSupport}
+import uk.gov.hmrc.mobilehelptosave.support.{MongoTestCollectionsDropAfterAll, OneServerPerSuiteWsClient, WireMockSupport}
 
 class InvitationSurveyAndWorkingTaxCreditsFilterISpec extends WordSpec with Matchers
   with FutureAwaits with DefaultAwaitTimeout with InvitationCleanup
-  with WireMockSupport with OneServerPerSuiteWsClient {
+  with WireMockSupport with MongoTestCollectionsDropAfterAll with OneServerPerSuiteWsClient {
 
   private val fixedClock = new FixedFakeClock(DateTime.parse("2018-02-08T12:34:56.000Z"))
 
-  override implicit lazy val app: Application = wireMockApplicationBuilder()
+  override implicit lazy val app: Application = appBuilder
     .configure(
       InvitationConfig.Enabled,
       "helpToSave.invitationFilters.survey" -> "true",

--- a/it/uk/gov/hmrc/mobilehelptosave/InvitationSurveyFilterISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/InvitationSurveyFilterISpec.scala
@@ -24,15 +24,15 @@ import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
 import uk.gov.hmrc.domain.Generator
 import uk.gov.hmrc.mobilehelptosave.services.{Clock, FixedFakeClock}
 import uk.gov.hmrc.mobilehelptosave.stubs.{AuthStub, HelpToSaveStub, NativeAppWidgetStub}
-import uk.gov.hmrc.mobilehelptosave.support.{OneServerPerSuiteWsClient, WireMockSupport}
+import uk.gov.hmrc.mobilehelptosave.support.{MongoTestCollectionsDropAfterAll, OneServerPerSuiteWsClient, WireMockSupport}
 
 class InvitationSurveyFilterISpec extends WordSpec with Matchers
   with FutureAwaits with DefaultAwaitTimeout with InvitationCleanup
-  with WireMockSupport with OneServerPerSuiteWsClient {
+  with WireMockSupport with MongoTestCollectionsDropAfterAll with OneServerPerSuiteWsClient {
 
   private val fixedClock = new FixedFakeClock(DateTime.parse("2018-02-08T12:34:56.000Z"))
 
-  override implicit lazy val app: Application = wireMockApplicationBuilder()
+  override implicit lazy val app: Application = appBuilder
     .configure(
       InvitationConfig.Enabled,
       "helpToSave.invitationFilters.survey" -> "true",

--- a/it/uk/gov/hmrc/mobilehelptosave/InvitationWorkingTaxCreditsFilterISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/InvitationWorkingTaxCreditsFilterISpec.scala
@@ -24,15 +24,15 @@ import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
 import uk.gov.hmrc.domain.Generator
 import uk.gov.hmrc.mobilehelptosave.services.{Clock, FixedFakeClock}
 import uk.gov.hmrc.mobilehelptosave.stubs.{AuthStub, HelpToSaveStub, TaxCreditBrokerStub}
-import uk.gov.hmrc.mobilehelptosave.support.{OneServerPerSuiteWsClient, WireMockSupport}
+import uk.gov.hmrc.mobilehelptosave.support.{MongoTestCollectionsDropAfterAll, OneServerPerSuiteWsClient, WireMockSupport}
 
 class InvitationWorkingTaxCreditsFilterISpec extends WordSpec with Matchers
   with FutureAwaits with DefaultAwaitTimeout with InvitationCleanup
-  with WireMockSupport with OneServerPerSuiteWsClient {
+  with WireMockSupport with MongoTestCollectionsDropAfterAll with OneServerPerSuiteWsClient {
 
   private val fixedClock = new FixedFakeClock(DateTime.parse("2018-02-08T12:34:56.000Z"))
 
-  override implicit lazy val app: Application = wireMockApplicationBuilder()
+  override implicit lazy val app: Application = appBuilder
     .configure(
       InvitationConfig.Enabled,
       "helpToSave.invitationFilters.survey" -> "false",

--- a/it/uk/gov/hmrc/mobilehelptosave/StartupISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/StartupISpec.scala
@@ -22,13 +22,13 @@ import play.api.libs.json.{JsLookupResult, JsUndefined}
 import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
 import uk.gov.hmrc.domain.Generator
 import uk.gov.hmrc.mobilehelptosave.stubs.{AuthStub, HelpToSaveProxyStub, HelpToSaveStub}
-import uk.gov.hmrc.mobilehelptosave.support.{OneServerPerSuiteWsClient, WireMockSupport}
+import uk.gov.hmrc.mobilehelptosave.support.{MongoTestCollectionsDropAfterAll, OneServerPerSuiteWsClient, WireMockSupport}
 
 class StartupISpec extends WordSpec with Matchers
   with FutureAwaits with DefaultAwaitTimeout with InvitationCleanup
-  with WireMockSupport with OneServerPerSuiteWsClient {
+  with WireMockSupport with MongoTestCollectionsDropAfterAll with OneServerPerSuiteWsClient {
 
-  override implicit lazy val app: Application = wireMockApplicationBuilder()
+  override implicit lazy val app: Application = appBuilder
     .configure(
       InvitationConfig.Enabled,
       "helpToSave.invitationFilters.survey" -> "false",

--- a/it/uk/gov/hmrc/mobilehelptosave/support/AppBuilder.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/support/AppBuilder.scala
@@ -14,16 +14,10 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.mobilehelptosave.repos
+package uk.gov.hmrc.mobilehelptosave.support
 
-import org.scalatest.TestSuite
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.Application
-import uk.gov.hmrc.mobilehelptosave.support.MongoTestCollectionsDropAfterAll
-import uk.gov.hmrc.mongo.ReactiveRepository
+import play.api.inject.guice.GuiceApplicationBuilder
 
-trait MongoRepositoryISpec[A <: Any, ID <: Any] extends RepositorySpec[A, ID] with MongoTestCollectionsDropAfterAll with GuiceOneAppPerSuite { this: TestSuite =>
-  final override implicit lazy val app: Application = appBuilder
-    .build()
-  override val repo: ReactiveRepository[A, ID] with TestableRepository[A, ID]
+trait AppBuilder {
+  protected def appBuilder: GuiceApplicationBuilder = new GuiceApplicationBuilder()
 }

--- a/it/uk/gov/hmrc/mobilehelptosave/support/MongoTestCollections.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/support/MongoTestCollections.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.mobilehelptosave.support
+
+import java.util.UUID
+
+import org.scalatest.{BeforeAndAfterAll, Suite}
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
+import play.modules.reactivemongo.ReactiveMongoComponent
+import reactivemongo.api.DefaultDB
+import reactivemongo.play.json.collection.JSONCollection
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+/**
+  * Use differently-named collections to avoid interfering with non-test data.
+  *
+  * To use:
+  * - mix in this trait into Specs
+  * - in Specs:
+  *   - build the app from appBuilder
+  *     and
+  *   - call dropTestCollections() just before stopping the test Play Application (or use MongoTestCollectionsDropAfterAll)
+  * - in repositories, suffix the collection name with the value of the `mongodb.collectionName.suffix` app config property
+  */
+trait MongoTestCollections extends AppBuilder {
+  protected lazy val collectionNameSuffix = s"-test-${UUID.randomUUID()}"
+
+  override protected def appBuilder: GuiceApplicationBuilder = super.appBuilder.configure("mongodb.collectionName.suffix" -> collectionNameSuffix)
+
+  protected def db(app: Application): DefaultDB = app.injector.instanceOf[ReactiveMongoComponent].mongoConnector.db()
+
+  protected def dropTestCollections(db: DefaultDB): Future[Unit] = {
+    db.collectionNames.map { collectionNames =>
+      val dropOFs: Seq[Option[Future[Boolean]]] = collectionNames.map { collectionName =>
+        if (collectionName.endsWith(collectionNameSuffix)) {
+          val dropF = db.collection[JSONCollection](collectionName).drop(failIfNotFound = true)
+          Some(dropF)
+        } else {
+          None
+        }
+      }
+      val dropFs: Seq[Future[Boolean]] = dropOFs.flatten
+      Future.sequence(dropFs)
+    }
+  }
+}
+
+trait MongoTestCollectionsDropAfterAll extends MongoTestCollections with BeforeAndAfterAll with FutureAwaits with DefaultAwaitTimeout { this: Suite =>
+  protected def app: Application
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+
+    await(dropTestCollections(db(app)))
+  }
+}

--- a/it/uk/gov/hmrc/mobilehelptosave/support/WireMockSupport.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/support/WireMockSupport.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.play.it.Port
 
 case class WireMockBaseUrl(value: URL)
 
-trait WireMockSupport extends BeforeAndAfterAll with BeforeAndAfterEach {
+trait WireMockSupport extends BeforeAndAfterAll with BeforeAndAfterEach with AppBuilder {
   me: Suite =>
 
   val wireMockPort: Int = Port.randomAvailable
@@ -57,14 +57,12 @@ trait WireMockSupport extends BeforeAndAfterAll with BeforeAndAfterEach {
     WireMock.reset()
   }
 
-  def wireMockApplicationBuilder(): GuiceApplicationBuilder =
-    new GuiceApplicationBuilder()
-      .configure(
-        "auditing.enabled" -> false,
-        "microservice.services.auth.port" -> wireMockPort,
-        "microservice.services.help-to-save.port" -> wireMockPort,
-        "microservice.services.help-to-save-proxy.port" -> wireMockPort,
-        "microservice.services.native-app-widget.port" -> wireMockPort,
-        "microservice.services.tax-credits-broker.port" -> wireMockPort
-      )
+  override protected def appBuilder: GuiceApplicationBuilder = super.appBuilder.configure(
+    "auditing.enabled" -> false,
+    "microservice.services.auth.port" -> wireMockPort,
+    "microservice.services.help-to-save.port" -> wireMockPort,
+    "microservice.services.help-to-save-proxy.port" -> wireMockPort,
+    "microservice.services.native-app-widget.port" -> wireMockPort,
+    "microservice.services.tax-credits-broker.port" -> wireMockPort
+  )
 }


### PR DESCRIPTION
...not just the repository integration tests.

This means that the integration tests shouldn't touch the non-test collections at all now.