### PR TITLE
[NGC-3199][FD] Enable account feature flags by default

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -186,9 +186,9 @@ microservice {
 
 helpToSave {
   enabled = true
-  balanceEnabled = false
-  paidInThisMonthEnabled = false
-  firstBonusEnabled = false
+  balanceEnabled = true
+  paidInThisMonthEnabled = true
+  firstBonusEnabled = true
   shareInvitationEnabled = true
   savingRemindersEnabled = true
   infoUrl = "https://www.gov.uk/government/publications/help-to-save-what-it-is-and-who-its-for/the-help-to-save-scheme"


### PR DESCRIPTION
...so that account data in response can be tested by mobile-help-to-save-multi-service-integration-tests, which runs services with their default configuration.