### PR TITLE
[NGC-3199][FD] Don't validate actual values of feature flags

### DIFF
--- a/it/uk/gov/hmrc/mobilehelptosave/StartupConfigISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/StartupConfigISpec.scala
@@ -27,13 +27,13 @@ import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
 import uk.gov.hmrc.domain.Generator
 import uk.gov.hmrc.mobilehelptosave.domain.InternalAuthId
 import uk.gov.hmrc.mobilehelptosave.stubs.{AuthStub, HelpToSaveProxyStub, HelpToSaveStub}
-import uk.gov.hmrc.mobilehelptosave.support.{MongoTestCollections, WireMockSupport, WithTestServer}
+import uk.gov.hmrc.mobilehelptosave.support.{JsonMatchers, MongoTestCollections, WireMockSupport, WithTestServer}
 
 /**
   * Tests that the startup endpoint uses configuration values correctly
   * (e.g. changes its response when configuration is changed).
   */
-class StartupConfigISpec extends WordSpec with Matchers with FutureAwaits with DefaultAwaitTimeout
+class StartupConfigISpec extends WordSpec with Matchers with JsonMatchers with FutureAwaits with DefaultAwaitTimeout
   with WsScalaTestClient with WireMockSupport with MongoTestCollections with WithTestServer {
 
   private val internalAuthId = InternalAuthId("test-internal-auth-id")
@@ -140,7 +140,7 @@ class StartupConfigISpec extends WordSpec with Matchers with FutureAwaits with D
       HelpToSaveProxyStub.nsiAccountShouldNotHaveBeenCalled()
     }
 
-    "include default feature flag and URL settings when their configuration is not overridden" in withTestServerAndMongoCleanup(
+    "include feature flag and URL settings when their configuration is not overridden" in withTestServerAndMongoCleanup(
       appBuilder
         .configure("helpToSave.enabled" -> true)
         .configure(InvitationConfig.NoFilters: _*)
@@ -153,11 +153,11 @@ class StartupConfigISpec extends WordSpec with Matchers with FutureAwaits with D
 
       val response = await(wsUrl("/mobile-help-to-save/startup").get())
       response.status shouldBe 200
-      (response.json \ "balanceEnabled").as[Boolean] shouldBe false
-      (response.json \ "paidInThisMonthEnabled").as[Boolean] shouldBe false
-      (response.json \ "firstBonusEnabled").as[Boolean] shouldBe false
-      (response.json \ "shareInvitationEnabled").as[Boolean] shouldBe true
-      (response.json \ "savingRemindersEnabled").as[Boolean] shouldBe true
+      (response.json \ "balanceEnabled").validate[Boolean] should beJsSuccess
+      (response.json \ "paidInThisMonthEnabled").validate[Boolean] should beJsSuccess
+      (response.json \ "firstBonusEnabled").validate[Boolean] should beJsSuccess
+      (response.json \ "shareInvitationEnabled").validate[Boolean] should beJsSuccess
+      (response.json \ "savingRemindersEnabled").validate[Boolean] should beJsSuccess
       (response.json \ "infoUrl").as[String] shouldBe "https://www.gov.uk/government/publications/help-to-save-what-it-is-and-who-its-for/the-help-to-save-scheme"
       (response.json \ "invitationUrl").as[String] shouldBe "http://localhost:8249/mobile-help-to-save"
       (response.json \ "accessAccountUrl").as[String] shouldBe "http://localhost:8249/mobile-help-to-save/access-account"

--- a/it/uk/gov/hmrc/mobilehelptosave/support/JsonMatchers.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/support/JsonMatchers.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.mobilehelptosave.support
+
+import org.scalatest.matchers.{MatchResult, Matcher}
+import play.api.libs.json.{JsError, JsResult, JsSuccess}
+
+trait JsonMatchers {
+  val beJsSuccess: Matcher[JsResult[_]] = new Matcher[JsResult[_]] {
+    override def apply(left: JsResult[_]): MatchResult = left match {
+      case JsSuccess(_, _) => MatchResult(matches = true, "JsResult was an error", "JsResult was successful")
+      case JsError(errors) => MatchResult(matches = false, s"JsResult was an error: $errors", "JsResult was successful")
+    }
+  }
+}


### PR DESCRIPTION
That seems like over-testing and meant we'd need to update the test every time we changed the defaults in application.conf.

Instead test that the flags are present in the response JSON as valid Booleans.