### PR TITLE
[FD] Remove build setting that is redundant according to PLATOPS-1409

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,6 @@ PlayKeys.playDefaultPort := 8248
 scalacOptions += "-Ypartial-unification"
 
 AppDependencies.appDependencies
-retrieveManaged := true
 evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false)
 
 unmanagedSourceDirectories in Test += baseDirectory.value / "testcommon"


### PR DESCRIPTION
I have a hunch that this `retrieveManaged := true` was responsible for library sources not being available in IntellIJ until `sbt updateClassifiers` was done, however haven't been able to prove this as I haven't been able to reproduce the problem.