### PR TITLE
[FD] Turn off unwanted auditing and logging for SandboxController

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -97,13 +97,16 @@ play.http.router=prod.Routes
 controllers {
 
   com.kenshoo.play.metrics.MetricsController = {
-    needsAuth = false
     needsLogging = false
     needsAuditing = false
   }
 
   uk.gov.hmrc.mobilehelptosave.controllers.StartupController = {
-    needsAuth = false
+    needsLogging = false
+    needsAuditing = false
+  }
+
+  uk.gov.hmrc.mobilehelptosave.controllers.SandboxController = {
     needsLogging = false
     needsAuditing = false
   }


### PR DESCRIPTION
needsLogging and needsAuditing both default to true if not specified, see uk.gov.hmrc.play.bootstrap.config.ControllerConfigs.get(controllerName: String).

Also remove unused needsAuth config from other controllers.