### PR TITLE
[NGC-4102][FD] Add test for rewritten warning code

### DIFF
--- a/test/uk/gov/hmrc/mobilehelptosave/services/HelpToSaveAccountServiceSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/services/HelpToSaveAccountServiceSpec.scala
@@ -61,6 +61,8 @@ class HelpToSaveAccountServiceSpec extends WordSpec with Matchers
       val fakeEnrolmentStatus = fakeHelpToSaveEnrolmentStatus(nino, Right(false))
       val service = new HelpToSaveAccountService(logger, fakeEnrolmentStatus, ShouldNotBeCalledGetAccount, testConfig)
       await(service.account(nino)) shouldBe Right(None)
+
+      (slf4jLoggerStub.warn(_: String)) verify * never()
     }
 
     "return None and log a warning when user is enrolled according to help-to-save but no account exists in NS&I" in {


### PR DESCRIPTION
Moving the enrolment check logic from HelpToSaveController into HelpToSaveAccountService (NGC-3812) coincidentally fixed the unwanted warnings (NGC-4102). This commit adds a test to help prevent regressions of NGC-4102.