### PR TITLE
[FD] Prepare for Play 2.6

### DIFF
--- a/it/uk/gov/hmrc/mobilehelptosave/stubs/AuthStub.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/stubs/AuthStub.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.mobilehelptosave.stubs
 
+import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
 import play.api.libs.json.Json
 import uk.gov.hmrc.domain.Nino
@@ -32,8 +33,8 @@ object AuthStub {
   }
 
 
-  def userIsLoggedIn(nino: Nino): Unit =
-    stubFor(post(urlPathEqualTo("/auth/authorise"))
+  def userIsLoggedIn(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.stubFor(post(urlPathEqualTo("/auth/authorise"))
       .withRequestBody(equalToJson(authoriseRequestBody))
       .willReturn(aResponse()
         .withStatus(200)
@@ -43,22 +44,22 @@ object AuthStub {
           ).toString
         )))
 
-  def userIsLoggedInWithInsufficientConfidenceLevel(): Unit =
-    stubFor(post(urlPathEqualTo("/auth/authorise"))
+  def userIsLoggedInWithInsufficientConfidenceLevel()(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.stubFor(post(urlPathEqualTo("/auth/authorise"))
       .withRequestBody(equalToJson(authoriseRequestBody))
       .willReturn(aResponse()
         .withStatus(401)
         .withHeader("WWW-Authenticate", """MDTP detail="InsufficientConfidenceLevel"""")
       ))
 
-  def userIsNotLoggedIn(): Unit =
-    stubFor(post(urlPathEqualTo("/auth/authorise"))
+  def userIsNotLoggedIn()(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.stubFor(post(urlPathEqualTo("/auth/authorise"))
       .withRequestBody(equalToJson(authoriseRequestBody))
       .willReturn(aResponse()
         .withStatus(401)
-          .withHeader("WWW-Authenticate", """MDTP detail="MissingBearerToken"""")
+        .withHeader("WWW-Authenticate", """MDTP detail="MissingBearerToken"""")
       ))
 
-  def authoriseShouldNotHaveBeenCalled(): Unit =
-    verify(0, postRequestedFor(urlPathEqualTo("/auth/authorise")))
+  def authoriseShouldNotHaveBeenCalled()(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.verify(0, postRequestedFor(urlPathEqualTo("/auth/authorise")))
 }

--- a/it/uk/gov/hmrc/mobilehelptosave/stubs/HelpToSaveStub.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/stubs/HelpToSaveStub.scala
@@ -16,61 +16,62 @@
 
 package uk.gov.hmrc.mobilehelptosave.stubs
 
+import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
 import play.api.http.Status
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.mobilehelptosave.{AccountTestData, TransactionTestData}
 
 object HelpToSaveStub extends AccountTestData with TransactionTestData {
-  def currentUserIsEnrolled(): Unit = enrolmentStatusIs(true)
-  def currentUserIsNotEnrolled(): Unit = enrolmentStatusIs(false)
+  def currentUserIsEnrolled()(implicit wireMockServer: WireMockServer): Unit = enrolmentStatusIs(true)
+  def currentUserIsNotEnrolled()(implicit wireMockServer: WireMockServer): Unit = enrolmentStatusIs(false)
 
-  def enrolmentStatusShouldNotHaveBeenCalled(): Unit =
-    verify(0, getRequestedFor(urlPathEqualTo("/help-to-save/enrolment-status")))
+  def enrolmentStatusShouldNotHaveBeenCalled()(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.verify(0, getRequestedFor(urlPathEqualTo("/help-to-save/enrolment-status")))
 
-  def enrolmentStatusReturnsInternalServerError(): Unit =
-    stubFor(get(urlPathEqualTo("/help-to-save/enrolment-status"))
+  def enrolmentStatusReturnsInternalServerError()(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.stubFor(get(urlPathEqualTo("/help-to-save/enrolment-status"))
       .willReturn(aResponse()
         .withStatus(Status.INTERNAL_SERVER_ERROR)))
 
-  private def enrolmentStatusIs(status: Boolean): Unit =
-    stubFor(get(urlPathEqualTo("/help-to-save/enrolment-status"))
+  private def enrolmentStatusIs(status: Boolean)(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.stubFor(get(urlPathEqualTo("/help-to-save/enrolment-status"))
       .willReturn(aResponse()
         .withStatus(Status.OK)
         .withBody(
           s"""{"enrolled":$status}"""
         )))
 
-  def transactionsExistForUser(nino: Nino): Unit = {
-    stubFor(get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
+  def transactionsExistForUser(nino: Nino)(implicit wireMockServer: WireMockServer): Unit = {
+    wireMockServer.stubFor(get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
       .willReturn(aResponse()
         .withStatus(Status.OK)
         .withBody(transactionsReturnedByHelpToSaveJsonString)))
   }
 
-  def zeroTransactionsExistForUser(nino: Nino): Unit = {
-    stubFor(get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
+  def zeroTransactionsExistForUser(nino: Nino)(implicit wireMockServer: WireMockServer): Unit = {
+    wireMockServer.stubFor(get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
       .willReturn(aResponse()
         .withStatus(Status.OK)
         .withBody(zeroTransactionsReturnedByHelpToSaveJsonString)))
   }
 
-  def transactionsWithOver50PoundDebit(nino: Nino): Unit = {
-    stubFor(get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
+  def transactionsWithOver50PoundDebit(nino: Nino)(implicit wireMockServer: WireMockServer): Unit = {
+    wireMockServer.stubFor(get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
       .willReturn(aResponse()
         .withStatus(Status.OK)
         .withBody(transactionsWithOver50PoundDebitReturnedByHelpToSaveJsonString)))
   }
 
-  def multipleTransactionsWithinSameMonthAndDay(nino: Nino): Unit = {
-    stubFor(get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
+  def multipleTransactionsWithinSameMonthAndDay(nino: Nino)(implicit wireMockServer: WireMockServer): Unit = {
+    wireMockServer.stubFor(get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
       .willReturn(aResponse()
         .withStatus(Status.OK)
         .withBody(multipleTransactionsWithinSameMonthAndDayReturnedByHelpToSaveJsonString)))
   }
 
-  def userDoesNotHaveAnHtsAccount(nino: Nino): Unit = {
-    stubFor(get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
+  def userDoesNotHaveAnHtsAccount(nino: Nino)(implicit wireMockServer: WireMockServer): Unit = {
+    wireMockServer.stubFor(get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
       .willReturn(aResponse()
         .withStatus(Status.NOT_FOUND)))
   }
@@ -79,47 +80,47 @@ object HelpToSaveStub extends AccountTestData with TransactionTestData {
     urlPathEqualTo(s"/help-to-save/$nino/account")
   }
 
-  def accountShouldNotHaveBeenCalled(nino: Nino): Unit =
-    verify(0, getRequestedFor(getAccountUrlPathPattern(nino)))
+  def accountShouldNotHaveBeenCalled(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.verify(0, getRequestedFor(getAccountUrlPathPattern(nino)))
 
-  def accountExists(nino: Nino): Unit =
-    stubFor(get(getAccountUrlPathPattern(nino))
+  def accountExists(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.stubFor(get(getAccountUrlPathPattern(nino))
       .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
       .willReturn(aResponse()
         .withStatus(200)
         .withBody(accountReturnedByHelpToSaveJsonString)))
 
-  def accountExistsWithNoEmail(nino: Nino): Unit =
-    stubFor(get(getAccountUrlPathPattern(nino))
+  def accountExistsWithNoEmail(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.stubFor(get(getAccountUrlPathPattern(nino))
       .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
       .willReturn(aResponse()
         .withStatus(200)
         .withBody(accountWithNoEmailReturnedByHelpToSaveJsonString)))
 
-  def closedAccountExists(nino: Nino): Unit =
-    stubFor(get(getAccountUrlPathPattern(nino))
+  def closedAccountExists(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.stubFor(get(getAccountUrlPathPattern(nino))
       .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
       .willReturn(aResponse()
         .withStatus(200)
         .withBody(closedAccountReturnedByHelpToSaveJsonString)))
 
-  def blockedAccountExists(nino: Nino): Unit =
-    stubFor(get(getAccountUrlPathPattern(nino))
+  def blockedAccountExists(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.stubFor(get(getAccountUrlPathPattern(nino))
       .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
       .willReturn(aResponse()
         .withStatus(200)
         .withBody(enrolledButBlockedReturnedByHelpToSaveJsonString)))
 
 
-  def accountReturnsInvalidJson(nino: Nino): Unit =
-    stubFor(get(getAccountUrlPathPattern(nino))
+  def accountReturnsInvalidJson(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.stubFor(get(getAccountUrlPathPattern(nino))
       .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
       .willReturn(aResponse()
         .withStatus(200)
         .withBody(accountReturnedByHelpToSaveInvalidJsonString)))
 
-  def accountReturnsBadlyFormedJson(nino: Nino): Unit =
-    stubFor(get(getAccountUrlPathPattern(nino))
+  def accountReturnsBadlyFormedJson(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.stubFor(get(getAccountUrlPathPattern(nino))
       .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
       .willReturn(aResponse()
         .withStatus(200)
@@ -127,8 +128,8 @@ object HelpToSaveStub extends AccountTestData with TransactionTestData {
           """not JSON""".stripMargin
         )))
 
-  def accountReturnsInternalServerError(nino: Nino): Unit =
-    stubFor(get(getAccountUrlPathPattern(nino))
+  def accountReturnsInternalServerError(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.stubFor(get(getAccountUrlPathPattern(nino))
       .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
       .willReturn(aResponse()
         .withStatus(500)))

--- a/it/uk/gov/hmrc/mobilehelptosave/stubs/ServiceLocatorStub.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/stubs/ServiceLocatorStub.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.mobilehelptosave.stubs
 
+import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
 import play.api.libs.json.Json
@@ -23,14 +24,14 @@ import uk.gov.hmrc.api.domain.Registration
 
 object ServiceLocatorStub {
 
-  def registerShouldHaveBeenCalled(serviceName: String, serviceUrl: String): Unit =
-    verify(1, registrationPattern(serviceName, serviceUrl))
+  def registerShouldHaveBeenCalled(serviceName: String, serviceUrl: String)(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.verify(1, registrationPattern(serviceName, serviceUrl))
 
-  def registerShouldNotHaveBeenCalled(serviceName: String, serviceUrl: String): Unit =
-    verify(0, registrationPattern(serviceName, serviceUrl))
+  def registerShouldNotHaveBeenCalled(serviceName: String, serviceUrl: String)(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.verify(0, registrationPattern(serviceName, serviceUrl))
 
-  def registrationSucceeds(): Unit =
-    stubFor(post(urlPathEqualTo("/registration"))
+  def registrationSucceeds()(implicit wireMockServer: WireMockServer): Unit =
+    wireMockServer.stubFor(post(urlPathEqualTo("/registration"))
       .willReturn(aResponse()
         .withStatus(204)))
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -12,7 +12,7 @@ object AppDependencies {
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc" %% "bootstrap-play-25" % "3.7.0" withSources(),
+    "uk.gov.hmrc" %% "bootstrap-play-25" % "3.14.0" withSources(),
     "uk.gov.hmrc" %% "domain" % "5.2.0",
     "org.typelevel" %% "cats-core" % "1.1.0",
     "io.lemonlabs" %% "scala-uri" % "1.1.1",
@@ -24,12 +24,11 @@ object AppDependencies {
   )
 
   val integrationTest: Seq[ModuleID] = testCommon("it") ++ Seq (
-    "com.github.tomakehurst" % "wiremock" % "2.13.0" % "it"
+    "com.github.tomakehurst" % "wiremock" % "2.19.0" % "it"
   )
 
   def testCommon(scope: String) = Seq(
-    "uk.gov.hmrc" %% "hmrctest" % "3.1.0" % scope,
-    "org.scalatest" %% "scalatest" % "3.0.4" % scope,
+    "org.scalatest" %% "scalatest" % "3.0.5" % scope,
     "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.1" % scope,
     "org.pegdown" % "pegdown" % "1.6.0" % scope,
     "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,11 +5,11 @@ resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.13.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.10.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.14.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.2.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 

--- a/test/uk/gov/hmrc/mobilehelptosave/connectors/HelpToSaveConnectorSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/connectors/HelpToSaveConnectorSpec.scala
@@ -20,22 +20,23 @@ import java.net.{ConnectException, URL}
 
 import io.lemonlabs.uri._
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.OneInstancePerTest
+import org.scalatest.{Matchers, OneInstancePerTest, WordSpec}
 import play.api.libs.json.{JsObject, Json}
+import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.mobilehelptosave.config.HelpToSaveConnectorConfig
 import uk.gov.hmrc.mobilehelptosave.domain.ErrorInfo
 import uk.gov.hmrc.mobilehelptosave.support.{FakeHttpGet, LoggerStub, ThrowableWithMessageContaining}
 import uk.gov.hmrc.mobilehelptosave.{AccountTestData, TransactionTestData}
-import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.Future._
 
 class HelpToSaveConnectorSpec
-  extends UnitSpec
+  extends WordSpec with Matchers
+    with FutureAwaits with DefaultAwaitTimeout
     with MockFactory with OneInstancePerTest with LoggerStub with ThrowableWithMessageContaining
     with AccountTestData with TransactionTestData {
 
@@ -65,8 +66,10 @@ class HelpToSaveConnectorSpec
   }
 
   private def httpGet(path: String, response: Future[HttpResponse]) = FakeHttpGet(s"$baseUrl/help-to-save/$path", response)
+  private def httpGet(path: String, response: HttpResponse) = FakeHttpGet(s"$baseUrl/help-to-save/$path", response)
 
   private def httpGet(predicate: String => Boolean, response: Future[HttpResponse]) = FakeHttpGet(predicate, response)
+  private def httpGet(predicate: String => Boolean, response: HttpResponse) = FakeHttpGet(predicate, response)
 
 
   private val config: HelpToSaveConnectorConfig = new HelpToSaveConnectorConfig {

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/AuthorisedWithIdsSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/AuthorisedWithIdsSpec.scala
@@ -19,21 +19,24 @@ package uk.gov.hmrc.mobilehelptosave.controllers
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.OneInstancePerTest
+import org.scalatest.{Matchers, OneInstancePerTest, WordSpec}
 import play.api.http.Status._
-import play.api.mvc.Results
-import play.api.test.FakeRequest
+import play.api.mvc.{Result, Results}
+import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
+import play.api.test.Helpers.{contentAsString, status}
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, Retrievals}
 import uk.gov.hmrc.domain.{Generator, Nino}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mobilehelptosave.support.LoggerStub
-import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class AuthorisedWithIdsSpec extends UnitSpec with MockFactory with OneInstancePerTest with LoggerStub with Retrievals with Results {
+class AuthorisedWithIdsSpec
+  extends WordSpec with Matchers
+    with FutureAwaits with DefaultAwaitTimeout
+    with MockFactory with OneInstancePerTest with LoggerStub with Retrievals with Results {
 
   private val generator = new Generator(0)
   private val testNino = generator.nextNino
@@ -101,9 +104,9 @@ class AuthorisedWithIdsSpec extends UnitSpec with MockFactory with OneInstancePe
         Ok
       }
 
-      val result = await(action(FakeRequest()))
-      status(result) shouldBe FORBIDDEN
-      bodyOf(result) shouldBe "Authorisation failure [Insufficient ConfidenceLevel]"
+      val resultF = action(FakeRequest())
+      status(resultF) shouldBe FORBIDDEN
+      contentAsString(resultF) shouldBe "Authorisation failure [Insufficient ConfidenceLevel]"
       (slf4jLoggerStub.warn(_: String)) verify "Forbidding access due to insufficient confidence level. User will see an error screen. To fix this see NGC-3381."
     }
   }

--- a/test/uk/gov/hmrc/mobilehelptosave/services/UserServiceSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/services/UserServiceSpec.scala
@@ -17,19 +17,20 @@
 package uk.gov.hmrc.mobilehelptosave.services
 
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{EitherValues, OneInstancePerTest}
+import org.scalatest.{EitherValues, Matchers, OneInstancePerTest, WordSpec}
+import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
 import uk.gov.hmrc.domain.Generator
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mobilehelptosave.connectors.HelpToSaveEnrolmentStatus
 import uk.gov.hmrc.mobilehelptosave.domain._
 import uk.gov.hmrc.mobilehelptosave.support.LoggerStub
-import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.ExecutionContext.Implicits.{global => passedEc}
 import scala.concurrent.{ExecutionContext, Future}
 
 class UserServiceSpec
-  extends UnitSpec
+  extends WordSpec with Matchers
+    with FutureAwaits with DefaultAwaitTimeout
     with MockFactory with OneInstancePerTest with LoggerStub
     with EitherValues {
 
@@ -83,7 +84,4 @@ class UserServiceSpec
       Future successful userIsEnrolledInHelpToSave
     }
   }
-
-  // disable implicit
-  override def liftFuture[A](v: A): Future[A] = super.liftFuture(v)
 }


### PR DESCRIPTION
There will probably be no Play 2.6 version of the hmrctest library.

Break dependency on hmrctest.

Also upgrade a few other HMRC libs/plugins platform dependencies just to keep up to date (not really Play 2.6-related).