### PR TITLE
[NGC-4157] Added API documentation for v1.1 to support savings targets

### DIFF
--- a/app/uk/gov/hmrc/mobilehelptosave/domain/Target.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/domain/Target.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.mobilehelptosave.domain
+
+import org.joda.time.DateTime
+import uk.gov.hmrc.domain.Nino
+
+case class Targets(nino: Nino, currentTarget: Option[Target], previousTargets: Seq[Target])
+
+class Target(amount: Double, createdAt: DateTime)

--- a/app/uk/gov/hmrc/mobilehelptosave/views/definition.scala.txt
+++ b/app/uk/gov/hmrc/mobilehelptosave/views/definition.scala.txt
@@ -23,7 +23,7 @@
       },
       {
         "version": "1.1",
-        "status": "BETA",
+        "status": "ALPHA",
         "endpointsEnabled": true,
         "access": @Json.toJson(apiAccess)
       }

--- a/app/uk/gov/hmrc/mobilehelptosave/views/definition.scala.txt
+++ b/app/uk/gov/hmrc/mobilehelptosave/views/definition.scala.txt
@@ -23,7 +23,7 @@
       },
       {
         "version": "1.1",
-        "status": "DEV",
+        "status": "BETA",
         "endpointsEnabled": true,
         "access": @Json.toJson(apiAccess)
       }

--- a/app/uk/gov/hmrc/mobilehelptosave/views/definition.scala.txt
+++ b/app/uk/gov/hmrc/mobilehelptosave/views/definition.scala.txt
@@ -20,6 +20,12 @@
         "status": "STABLE",
         "endpointsEnabled": true,
         "access": @Json.toJson(apiAccess)
+      },
+      {
+        "version": "1.1",
+        "status": "DEV",
+        "endpointsEnabled": true,
+        "access": @Json.toJson(apiAccess)
       }
     ]
   }

--- a/resources/public/api/conf/1.1/application.raml
+++ b/resources/public/api/conf/1.1/application.raml
@@ -114,13 +114,13 @@ traits:
   /targets/current-target:
      is: [headers.acceptHeader, loginRequired, permissionOnAccountNinoRequired, ninoInvalid, mobileHelpToSaveShuttered]
      put:
+       body:
+         application/json:
+           type: !include schemas/target.json
+           example: !include examples/target.json
        displayName: Set a new savings target
        description: Set a new savings target
        (annotations.scope): "write:native-apps-api-orchestration"
        securedBy: [ sec.oauth_2_0: { scopes: [ "write:native-apps-api-orchestration" ] } ]
        responses:
-         200:
-           body:
-             application/json:
-               type: !include schemas/target.json
-               example: !include examples/target.json
+         204:

--- a/resources/public/api/conf/1.1/application.raml
+++ b/resources/public/api/conf/1.1/application.raml
@@ -118,8 +118,15 @@ traits:
          application/json:
            type: !include schemas/target.json
            example: !include examples/target.json
-       displayName: Set a new savings target
-       description: Set a new savings target
+       displayName: Set a savings target for the user
+       description: Set a savings target for the user. This will replace any existing savings target.
+       (annotations.scope): "write:native-apps-api-orchestration"
+       securedBy: [ sec.oauth_2_0: { scopes: [ "write:native-apps-api-orchestration" ] } ]
+       responses:
+         204:
+     delete:
+       displayName: Remove the users' current savings target
+       description: Remove the users' current savings target
        (annotations.scope): "write:native-apps-api-orchestration"
        securedBy: [ sec.oauth_2_0: { scopes: [ "write:native-apps-api-orchestration" ] } ]
        responses:

--- a/resources/public/api/conf/1.1/application.raml
+++ b/resources/public/api/conf/1.1/application.raml
@@ -112,15 +112,15 @@ traits:
               example: !include examples/transactions.json
 
   /targets/current-target:
-    is: [headers.acceptHeader, loginRequired, permissionOnAccountNinoRequired, ninoInvalid, mobileHelpToSaveShuttered]
+     is: [headers.acceptHeader, loginRequired, permissionOnAccountNinoRequired, ninoInvalid, mobileHelpToSaveShuttered]
      get:
-        displayName: Get current savings target
-        description: Retrieve the details of the user's current savings target (if set)
-        (annotations.scope): "read:native-apps-api-orchestration"
-          securedBy: [ sec.oauth_2_0: { scopes: [ "read:native-apps-api-orchestration" ] } ]
-          responses:
-            200:
-              body:
-                application/json:
-                  type: !include schemas/target.json
-                  example: !include examples/target.json
+       displayName: Get current savings target
+       description: Retrieve the details of the user's current savings target (if set)
+       (annotations.scope): "read:native-apps-api-orchestration"
+       securedBy: [ sec.oauth_2_0: { scopes: [ "read:native-apps-api-orchestration" ] } ]
+       responses:
+         200:
+           body:
+             application/json:
+               type: !include schemas/target.json
+               example: !include examples/target.json

--- a/resources/public/api/conf/1.1/application.raml
+++ b/resources/public/api/conf/1.1/application.raml
@@ -1,0 +1,126 @@
+#%RAML 1.0
+title: Help To Save
+version: 1.1
+protocols: [ HTTPS ]
+baseUri: https://api.service.hmrc.gov.uk/
+
+mediaType: [ application/json, application/hal+json ]
+
+uses:
+  sec: https://developer.service.hmrc.gov.uk/api-documentation/assets/common/modules/securitySchemes.raml
+  headers: https://developer.service.hmrc.gov.uk/api-documentation/assets/common/modules/headers.raml
+  annotations: https://developer.service.hmrc.gov.uk/api-documentation/assets/common/modules/annotations.raml
+  types: https://developer.service.hmrc.gov.uk/api-documentation/assets/common/modules/types.raml
+
+types:
+  nino:
+    type: string
+    example: AA999999A
+
+traits:
+  loginRequired:
+    responses:
+      401:
+        body:
+          application/json:
+            type: types.errorResponse
+            examples:
+              invalidCredentials:
+                description: Invalid Authentication information provided.
+                value:
+                  code: INVALID_CREDENTIALS
+
+  permissionOnAccountNinoRequired:
+    responses:
+      403:
+        body:
+          application/json:
+            type: types.errorResponse
+            examples:
+              noPermissionOnAccountNino:
+                description: The logged in user is not permitted to access the Help to Save Savings Account for the specified NINO.
+                value:
+                  code: NO_PERMISSION_ON_ACCOUNT_NINO
+
+  ninoInvalid:
+    responses:
+      400:
+        body:
+          application/json:
+            type: types.errorResponse
+            examples:
+              ninoInvalid:
+                description: Invalid NINO (incorrect format)
+                value:
+                  code: NINO_INVALID
+
+  # We implement our own shuttering instead of using the API platform shuttering (<confluence>/display/DTRG/How+to+emergency+shutter+an+API)
+  # because:
+  # 1) The response returned when API platform shuttering is used (503 with code: "SERVER_ERROR") is difficult to distinguish from the response when certain errors occur.
+  # 2) API platform shuttering does not support custom error messages
+  #
+  # Note that api-documentation-frontend doesn't display anything for this
+  # trait, probably because it goes outside API platform norms (errors are
+  # usually specified using types.errorResponse, like in ninoInvalid above,
+  # but we have more fields in this error response than there are in the API
+  # platform standard error response so we can't use types.errorResponse).
+  mobileHelpToSaveShuttered:
+    responses:
+      # we'd rather use 503 instead of 521 but can't use 503 because the API platform nginx discards any bodies in 503 responses returned by microservices - see NGC-3396
+      521:
+        body:
+          application/json:
+            type: !include schemas/shuttering.json
+            example: !include examples/shuttering.json
+
+/individuals/mobile-help-to-save/savings-account/{nino}:
+  uriParameters:
+    nino:
+      description: Savings account holder's National Insurance Number
+      type: string
+      example: AA000003D
+  is: [headers.acceptHeader, loginRequired, permissionOnAccountNinoRequired, ninoInvalid, mobileHelpToSaveShuttered]
+  get:
+    displayName: Get account information
+    description: Retrieves the details of the Help to Save account
+    (annotations.scope): "read:native-apps-api-orchestration"
+    securedBy: [ sec.oauth_2_0: { scopes: [ "read:native-apps-api-orchestration" ] } ]
+    responses:
+      200:
+        body:
+          application/json:
+            type: !include schemas/account.json
+            example: !include examples/account.json
+      404:
+        body:
+          application/json:
+            type: types.errorResponse
+            example: !include examples/accountNotFound.json
+
+  /transactions:
+    is: [headers.acceptHeader, loginRequired, permissionOnAccountNinoRequired, ninoInvalid, mobileHelpToSaveShuttered]
+    get:
+      displayName: Get transactions
+      description: Retrieve the details of the transaction activity that has taken place on the HTS Account associated with the NINO provided. All movements on the account across all terms will be returned. Transactions will be returned in the reverse of the order they were applied to the account (i.e. newest first).
+      (annotations.scope): "read:native-apps-api-orchestration"
+      securedBy: [ sec.oauth_2_0: { scopes: [ "read:native-apps-api-orchestration" ] } ]
+      responses:
+        200:
+          body:
+            application/json:
+              type: !include schemas/transactions.json
+              example: !include examples/transactions.json
+
+  /targets/current-target:
+    is: [headers.acceptHeader, loginRequired, permissionOnAccountNinoRequired, ninoInvalid, mobileHelpToSaveShuttered]
+     get:
+        displayName: Get current savings target
+        description: Retrieve the details of the user's current savings target (if set)
+        (annotations.scope): "read:native-apps-api-orchestration"
+          securedBy: [ sec.oauth_2_0: { scopes: [ "read:native-apps-api-orchestration" ] } ]
+          responses:
+            200:
+              body:
+                application/json:
+                  type: !include schemas/target.json
+                  example: !include examples/target.json

--- a/resources/public/api/conf/1.1/application.raml
+++ b/resources/public/api/conf/1.1/application.raml
@@ -113,11 +113,11 @@ traits:
 
   /targets/current-target:
      is: [headers.acceptHeader, loginRequired, permissionOnAccountNinoRequired, ninoInvalid, mobileHelpToSaveShuttered]
-     get:
-       displayName: Get current savings target
-       description: Retrieve the details of the user's current savings target (if set)
-       (annotations.scope): "read:native-apps-api-orchestration"
-       securedBy: [ sec.oauth_2_0: { scopes: [ "read:native-apps-api-orchestration" ] } ]
+     put:
+       displayName: Set a new savings target
+       description: Set a new savings target
+       (annotations.scope): "write:native-apps-api-orchestration"
+       securedBy: [ sec.oauth_2_0: { scopes: [ "write:native-apps-api-orchestration" ] } ]
        responses:
          200:
            body:

--- a/resources/public/api/conf/1.1/examples/account.json
+++ b/resources/public/api/conf/1.1/examples/account.json
@@ -33,8 +33,6 @@
   "inAppPaymentsEnabled": false,
   "savingsTargetEnabled": true,
   "savingsTarget": {
-    "hasTarget": false,
-    "targetAmount":0,
-    "paidInThisMonth": 0
+    "targetAmount":21.50
   }
 }

--- a/resources/public/api/conf/1.1/examples/account.json
+++ b/resources/public/api/conf/1.1/examples/account.json
@@ -1,0 +1,35 @@
+{
+  "number": "1000000000001",
+  "isClosed": false,
+  "blocked": {
+    "unspecified": false
+  },
+  "balance": 200,
+  "openedYearMonth": "2018-01",
+  "paidInThisMonth": 50,
+  "canPayInThisMonth": 0,
+  "maximumPaidInThisMonth": 50,
+  "thisMonthEndDate": "2018-03-31",
+  "nextPaymentMonthStartDate": "2018-04-01",
+  "accountHolderName": "Testforename Testsurname",
+  "accountHolderEmail": "test@example.com",
+  "bonusTerms": [
+    {
+      "bonusEstimate": 100,
+      "bonusPaid": 0,
+      "endDate": "2019-10-31",
+      "bonusPaidOnOrAfterDate": "2019-11-01",
+      "balanceMustBeMoreThanForBonus": 0
+    },
+    {
+      "bonusEstimate": 0,
+      "bonusPaid": 0,
+      "endDate": "2021-10-31",
+      "bonusPaidOnOrAfterDate": "2021-11-01",
+      "balanceMustBeMoreThanForBonus": 200
+    }
+  ],
+  "currentBonusTerm": "First",
+  "inAppPaymentsEnabled": false,
+  "savingsTargetsEnabled": true
+}

--- a/resources/public/api/conf/1.1/examples/account.json
+++ b/resources/public/api/conf/1.1/examples/account.json
@@ -31,5 +31,10 @@
   ],
   "currentBonusTerm": "First",
   "inAppPaymentsEnabled": false,
-  "savingsTargetsEnabled": true
+  "savingsTargetEnabled": true,
+  "savingsTarget": {
+    "hasTarget": false,
+    "targetAmount":0,
+    "paidInThisMonth": 0
+  }
 }

--- a/resources/public/api/conf/1.1/examples/accountNotFound.json
+++ b/resources/public/api/conf/1.1/examples/accountNotFound.json
@@ -1,0 +1,4 @@
+{
+  "description": "No Help to Save account exists for the specified NINO.",
+  "code": "ACCOUNT_NOT_FOUND"
+}

--- a/resources/public/api/conf/1.1/examples/shuttering.json
+++ b/resources/public/api/conf/1.1/examples/shuttering.json
@@ -1,0 +1,5 @@
+{
+  "shuttered": true,
+  "title": "Service Unavailable",
+  "message": "You’ll be able to use the Help to Save service at 9am on Monday 29 May 2017."
+}

--- a/resources/public/api/conf/1.1/examples/target.json
+++ b/resources/public/api/conf/1.1/examples/target.json
@@ -1,0 +1,5 @@
+{
+  "targetAmount":21.50,
+  "paidInThisMonth": 18,
+  "message": "Fantastic! Only another £3.50 to meet your target!"
+}

--- a/resources/public/api/conf/1.1/examples/target.json
+++ b/resources/public/api/conf/1.1/examples/target.json
@@ -1,4 +1,3 @@
 {
-  "targetAmount":21.50,
-  "paidInThisMonth": 18
+  "targetAmount": 21.50
 }

--- a/resources/public/api/conf/1.1/examples/target.json
+++ b/resources/public/api/conf/1.1/examples/target.json
@@ -1,5 +1,4 @@
 {
   "targetAmount":21.50,
-  "paidInThisMonth": 18,
-  "message": "Fantastic! Only another £3.50 to meet your target!"
+  "paidInThisMonth": 18
 }

--- a/resources/public/api/conf/1.1/examples/transactions.json
+++ b/resources/public/api/conf/1.1/examples/transactions.json
@@ -1,0 +1,25 @@
+{
+  "transactions": [
+    {
+      "amount": 3.00,
+      "operation": "credit",
+      "transactionDate": "2018-02-18",
+      "accountingDate": "2018-02-18",
+      "balanceAfter": 3.00
+    },
+    {
+      "amount": 6.67,
+      "operation": "debit",
+      "transactionDate": "2018-02-20",
+      "accountingDate": "2018-02-22",
+      "balanceAfter": 9.67
+    },
+    {
+      "amount": 5.00,
+      "operation": "debit",
+      "transactionDate": "2018-02-25",
+      "accountingDate": "2018-02-25",
+      "balanceAfter": 4.67
+    }
+  ]
+}

--- a/resources/public/api/conf/1.1/schemas/account.json
+++ b/resources/public/api/conf/1.1/schemas/account.json
@@ -194,20 +194,18 @@
     },
     "savingsTargetEnabled": {
       "type": "boolean",
-      "description": "Is savings target enabled for this account?"
+      "description": "Is the savings target feature enabled for this account?"
     },
     "savingsTarget": {
       "type": "object",
       "properties": {
-        "hasTarget": {
-          "type": "boolean",
-          "description": "Has the user already set a savings target?"
-        },
         "targetAmount": {
           "type": "number",
-          "description": "The saving target set by the user"
+          "description": "The savings target set by the user"
         }
-      }
+      },
+      "description": "This element will be present if there is a target set, otherwise it will be omitted.",
+      "required": ["targetAmount"]
     }
   },
   "required": [
@@ -223,7 +221,6 @@
     "bonusTerms",
     "currentBonusTerm",
     "inAppPaymentsEnabled",
-    "savingsTargetEnabled",
-    "savingsTarget"
+    "savingsTargetEnabled"
   ]
 }

--- a/resources/public/api/conf/1.1/schemas/account.json
+++ b/resources/public/api/conf/1.1/schemas/account.json
@@ -1,0 +1,215 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "description": "The Help To Save account details",
+  "properties": {
+    "number": {
+      "type": "string",
+      "description": "Help to Save account number",
+      "examples": [
+        "1000000000001"
+      ]
+    },
+    "isClosed": {
+      "type": "boolean",
+      "description": "Is the account closed",
+      "examples": [
+        "false"
+      ]
+    },
+    "blocked": {
+      "type": "object",
+      "description": "Actions that are blocked for this account",
+      "properties": {
+        "unspecified" : {
+          "type": "boolean",
+          "description": "Some unspecified action(s) is/are blocked. More specific blocking flags may be added in a future version of the API.",
+          "examples": [
+            "false"
+          ]
+        }
+      },
+      "required": [
+        "unspecified"
+      ]
+    },
+    "balance": {
+      "type": "number",
+      "description": "The current account balance",
+      "examples": [
+        20.16
+      ]
+    },
+    "openedYearMonth": {
+      "type": "string",
+      "description": "The year and month the account was opened",
+      "minLength": 7,
+      "maxLength": 7,
+      "pattern": "^[0-9]{4}-[0-9]{2}$",
+      "examples": [
+        "2018-01"
+      ]
+    },
+    "paidInThisMonth": {
+      "type": "number",
+      "description": "The total money (credits) to the account this month",
+      "examples": [
+        5.00
+      ]
+    },
+    "canPayInThisMonth": {
+      "type": "number",
+      "description": "The remaining amount that can be credited to the account this month",
+      "examples": [
+        5.00
+      ]
+    },
+    "maximumPaidInThisMonth": {
+      "type": "number",
+      "description": "The maximum sum allowed to be paid (credited) in a month",
+      "examples": [
+        50
+      ]
+    },
+    "thisMonthEndDate": {
+      "type": "string",
+      "description": "The date the month ends",
+      "minLength": 10,
+      "maxLength": 10,
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "examples": [
+        "2018-03-31"
+      ]
+    },
+    "nextPaymentMonthStartDate": {
+      "type": "string",
+      "description": "The date the month ends",
+      "minLength": 10,
+      "maxLength": 10,
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "examples": [
+        "2018-04-01"
+      ]
+    },
+    "accountHolderName": {
+      "type": "string",
+      "description": "The account holder's name",
+      "examples": [
+        "John Test"
+      ]
+    },
+    "accountHolderEmail": {
+      "type": "string",
+      "description": "The account holder's email address",
+      "examples": [
+        "test@example.com"
+      ]
+    },
+    "bonusTerms": {
+      "type": "array",
+      "description": "The bonus terms applicable for the account",
+      "items": {
+        "type": "object",
+        "properties": {
+          "bonusEstimate": {
+            "type": "number",
+            "description": "The estimated value of the bonus to be applied",
+            "examples": [
+              100
+            ]
+          },
+          "bonusPaid": {
+            "type": "number",
+            "description": "The actual value of the bonus applied",
+            "examples": [
+              50
+            ]
+          },
+          "endDate": {
+            "type": "string",
+            "description": "The date the bonus term ends",
+            "minLength": 10,
+            "maxLength": 10,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "examples": [
+              "2019-10-31"
+            ]
+          },
+          "bonusPaidOnOrAfterDate": {
+            "type": "string",
+            "description": "The earliest date the bonus will be paid (i.e. on or after the date specified)",
+            "minLength": 10,
+            "maxLength": 10,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "examples": [
+              "2019-11-01"
+            ]
+          },
+          "balanceMustBeMoreThanForBonus": {
+            "type": "number",
+            "description": "The savings amount that needs to be exceeded (in this term) to earn a bonus",
+            "examples": [
+              20.58
+            ]
+          }
+        },
+        "required": [
+          "bonusEstimate",
+          "bonusPaid",
+          "endDate",
+          "bonusPaidOnOrAfterDate",
+          "balanceMustBeMoreThanForBonus"
+        ]
+      }
+    },
+    "closingBalance": {
+      "type": "number",
+      "description": "The balance before the final transaction to close the account (only present when isClosed=true)",
+      "examples": [
+        20.16
+      ]
+    },
+    "closureDate": {
+      "type": "string",
+      "description": "The date the account was closed (only present when isClosed=true)",
+      "minLength": 10,
+      "maxLength": 10,
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "examples": [
+        "2018-03-31"
+      ]
+    },
+    "currentBonusTerm": {
+      "type": "string",
+      "description": "What bonus term is the account currently in",
+      "examples": [
+        "First",
+        "Second",
+        "AfterFinalTerm"
+      ]
+    },
+    "inAppPaymentsEnabled": {
+      "type": "boolean",
+      "description": "Are in-app payments enabled for this account?"
+    },
+    "savingsTargetsEnabled": {
+      "type": "boolean",
+      "description": "Are savings targets enabled for this account?"
+    }
+  },
+  "required": [
+    "openedYearMonth",
+    "isClosed",
+    "blocked",
+    "balance",
+    "paidInThisMonth",
+    "canPayInThisMonth",
+    "maximumPaidInThisMonth",
+    "thisMonthEndDate",
+    "accountHolderName",
+    "bonusTerms",
+    "currentBonusTerm",
+    "inAppPaymentsEnabled",
+    "savingsTargetsEnabled"
+  ]
+}

--- a/resources/public/api/conf/1.1/schemas/account.json
+++ b/resources/public/api/conf/1.1/schemas/account.json
@@ -192,9 +192,22 @@
       "type": "boolean",
       "description": "Are in-app payments enabled for this account?"
     },
-    "savingsTargetsEnabled": {
+    "savingsTargetEnabled": {
       "type": "boolean",
-      "description": "Are savings targets enabled for this account?"
+      "description": "Is savings target enabled for this account?"
+    },
+    "savingsTarget": {
+      "type": "object",
+      "properties": {
+        "hasTarget": {
+          "type": "boolean",
+          "description": "Has the user already set a savings target?"
+        },
+        "targetAmount": {
+          "type": "number",
+          "description": "The saving target set by the user"
+        }
+      }
     }
   },
   "required": [
@@ -210,6 +223,7 @@
     "bonusTerms",
     "currentBonusTerm",
     "inAppPaymentsEnabled",
-    "savingsTargetsEnabled"
+    "savingsTargetEnabled",
+    "savingsTarget"
   ]
 }

--- a/resources/public/api/conf/1.1/schemas/shuttering.json
+++ b/resources/public/api/conf/1.1/schemas/shuttering.json
@@ -1,0 +1,32 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "properties": {
+    "shuttered": {
+      "type": "boolean",
+      "description": "Whether the endpoint is shuttered - always true in all instances of this schema because responses that conform to this schema are only returned when shuttering is enabled",
+      "examples": [
+        "true"
+      ]
+    },
+    "title": {
+      "type": "string",
+      "description": "Title to be shown to user",
+      "examples": [
+        "Service Unavailable"
+      ]
+    },
+    "message": {
+      "type": "string",
+      "description": "Message to be shown to user",
+      "examples": [
+        "You’ll be able to use the Help to Save service at 9am on Monday 29 May 2017."
+      ]
+    }
+  },
+  "required": [
+    "shuttered",
+    "title",
+    "message"
+  ]
+}

--- a/resources/public/api/conf/1.1/schemas/target.json
+++ b/resources/public/api/conf/1.1/schemas/target.json
@@ -5,23 +5,14 @@
   "properties": {
     "targetAmount": {
       "type": "number",
-      "description": "The target amount that the user wants to save each month",
+      "description": "The target amount that the user wants to save each month. This must be a number between 1 and the monthly savings limit (currently £50)",
       "examples": [
         21.50,
         45
       ]
-    },
-    "paidInThisMonth": {
-      "type": "number",
-      "description": "The amount the user has already saved this month",
-      "examples": [
-        0,
-        15.50
-      ]
     }
   },
   "required": [
-    "targetAmount",
-    "paidInThisMonth"
+    "targetAmount"
   ]
 }

--- a/resources/public/api/conf/1.1/schemas/target.json
+++ b/resources/public/api/conf/1.1/schemas/target.json
@@ -18,10 +18,10 @@
         0,
         15.50
       ]
-    },
-    "message": {
-      "type":"string",
-      "description": "A representative message that can be displayed to the user"
     }
-  }
+  },
+  "required": [
+    "targetAmount",
+    "paidInThisMonth"
+  ]
 }

--- a/resources/public/api/conf/1.1/schemas/target.json
+++ b/resources/public/api/conf/1.1/schemas/target.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "description": "The Help To Save account details",
+  "properties": {
+    "targetAmount": {
+      "type": "number",
+      "description": "The target amount that the user wants to save each month",
+      "examples": [
+        21.50,
+        45
+      ]
+    },
+    "paidInThisMonth": {
+      "type": "number",
+      "description": "The amount the user has already saved this month",
+      "examples": [
+        0,
+        15.50
+      ]
+    },
+    "message": {
+      "type":"string",
+      "description": "A representative message that can be displayed to the user"
+    }
+  }
+}

--- a/resources/public/api/conf/1.1/schemas/transactions.json
+++ b/resources/public/api/conf/1.1/schemas/transactions.json
@@ -1,0 +1,69 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "properties": {
+    "transactions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "type": "number",
+            "description": "The transaction value",
+            "examples": [
+              1.23
+            ]
+          },
+          "operation": {
+            "type": "string",
+            "description": "Credit or debit",
+            "minLength": 1,
+            "maxLength": 16,
+            "pattern": "^(credit|debit)$",
+            "examples": [
+              "credit",
+              "debit"
+            ]
+          },
+          "transactionDate": {
+            "type": "string",
+            "description": "Date that the transaction occurred",
+            "minLength": 10,
+            "maxLength": 10,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "examples": [
+              "2018-02-19"
+            ]
+          },
+          "accountingDate": {
+            "type": "string",
+            "description": "Date that the transaction was applied to the account.",
+            "minLength": 10,
+            "maxLength": 10,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "examples": [
+              "2018-02-19"
+            ]
+          },
+          "balanceAfter": {
+            "type": "number",
+            "description": "The account balance after this transaction was applied",
+            "examples": [
+              1.23
+            ]
+          }
+        },
+        "required": [
+          "amount",
+          "operation",
+          "transactionDate",
+          "accountingDate",
+          "balanceAfter"
+        ]
+      }
+    }
+  },
+  "required": [
+    "transactions"
+  ]
+}


### PR DESCRIPTION
This adds RAML documentation for the new savings target endpoints. 1.1 is currently marked as being ALPHA as it is still under discussion and subject to changes.