### PR TITLE
[NGC-4195][NGC-4196] 'Set Target' endpoint now checks if there's an account

### DIFF
--- a/app/uk/gov/hmrc/mobilehelptosave/config/MobileHelpToSaveConfig.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/config/MobileHelpToSaveConfig.scala
@@ -61,8 +61,6 @@ case class MobileHelpToSaveConfig @Inject()(
   override val helpToSaveInvitationUrl: String = configString("helpToSave.invitationUrl")
   override val helpToSaveAccessAccountUrl: String = configString("helpToSave.accessAccountUrl")
 
-  override val monthlySavingsLimit: Double = configDouble("helpToSave.monthlySavingLimit")
-
   private val accessConfig = configuration.underlying.getConfig("api.access")
   override val apiAccessType: String = accessConfig.getString("type")
   override val apiWhiteListApplicationIds: Seq[String] = accessConfig.getStringList("white-list.applicationIds").asScala
@@ -118,5 +116,4 @@ trait StartupControllerConfig {
 @ImplementedBy(classOf[MobileHelpToSaveConfig])
 trait HelpToSaveControllerConfig {
   def shuttering: Shuttering
-  def monthlySavingsLimit: Double
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -192,7 +192,6 @@ helpToSave {
   infoUrl = "https://www.gov.uk/get-help-savings-low-income"
   invitationUrl = "http://localhost:8249/mobile-help-to-save"
   accessAccountUrl = "http://localhost:8249/mobile-help-to-save/access-account"
-  monthlySavingLimit = 50
   shuttering = {
     shuttered = false
     title = ""

--- a/it/uk/gov/hmrc/mobilehelptosave/SavingsTargetsISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/SavingsTargetsISpec.scala
@@ -49,7 +49,6 @@ class SavingsTargetsISpec
     val validTargetJson = Json.toJson(SavingsTarget(20))
 
     "respond with 204" in {
-
       HelpToSaveStub.currentUserIsEnrolled()
       HelpToSaveStub.accountExistsWithNoEmail(nino)
       AuthStub.userIsLoggedIn(nino)
@@ -57,6 +56,18 @@ class SavingsTargetsISpec
       val response: WSResponse = await(wsUrl(s"/savings-account/$nino/targets/current-target").put(validTargetJson))
 
       response.status shouldBe 204
+    }
+
+    "respond with 404 and account not found when user is not enrolled" in {
+      HelpToSaveStub.currentUserIsNotEnrolled()
+      AuthStub.userIsLoggedIn(nino)
+
+      val response: WSResponse = await(wsUrl(s"/savings-account/$nino/targets/current-target").put(validTargetJson))
+
+      (response.json\ "code").as[String] shouldBe "ACCOUNT_NOT_FOUND"
+      (response.json\ "message").as[String] shouldBe "No Help to Save account exists for the specified NINO"
+
+      response.status shouldBe 404
     }
 
     "return 401 when the user is not logged in" in {

--- a/it/uk/gov/hmrc/mobilehelptosave/SavingsTargetsISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/SavingsTargetsISpec.scala
@@ -25,7 +25,7 @@ import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
 import uk.gov.hmrc.domain.Generator
 import uk.gov.hmrc.mobilehelptosave.domain.SavingsTarget
 import uk.gov.hmrc.mobilehelptosave.scalatest.SchemaMatchers
-import uk.gov.hmrc.mobilehelptosave.stubs.AuthStub
+import uk.gov.hmrc.mobilehelptosave.stubs.{AuthStub, HelpToSaveStub}
 import uk.gov.hmrc.mobilehelptosave.support.{OneServerPerSuiteWsClient, WireMockSupport}
 
 class SavingsTargetsISpec
@@ -50,6 +50,8 @@ class SavingsTargetsISpec
 
     "respond with 204" in {
 
+      HelpToSaveStub.currentUserIsEnrolled()
+      HelpToSaveStub.accountExistsWithNoEmail(nino)
       AuthStub.userIsLoggedIn(nino)
 
       val response: WSResponse = await(wsUrl(s"/savings-account/$nino/targets/current-target").put(validTargetJson))

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/SandboxControllerSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/SandboxControllerSpec.scala
@@ -53,7 +53,7 @@ class SandboxControllerSpec
   private val nino = generator.nextNino
   private val shuttering = Shuttering(shuttered = false, "", "")
   private val shutteredShuttering = Shuttering(shuttered = true, "Gad Dangit!", "This service is shuttered")
-  private val config = TestHelpToSaveControllerConfig(shuttering, 50.0)
+  private val config = TestHelpToSaveControllerConfig(shuttering)
   private val currentTime = new DateTime(2018, 9, 29, 12, 30, DateTimeZone.forID("Europe/London"))
   private val fixedClock = new FixedFakeClock(currentTime)
   private val controller: SandboxController = new SandboxController(logger, config, SandboxData(logger, fixedClock, TestSandboxDataConfig))


### PR DESCRIPTION
The `setSavingsTarget` controller action now does a lookup to check that an account exists at NS&I for the NINO and will respond with 404 if not (NGC-4159). 

The controller will now also use the value of the `maximumPaidInThisMonth` from the NS&I account to validate the upper bound on the savings target (NGC-4196) so we no longer need to have configuration in this service for the maximum savings, and if it ever changes either globally or for individual accounts then we won't need to change this service to accommodate that.