### PR TITLE
[NGC-4209] Backport api 1.1 changes to 1.0

### DIFF
--- a/resources/public/api/conf/1.0/application.raml
+++ b/resources/public/api/conf/1.0/application.raml
@@ -111,3 +111,29 @@ traits:
               type: !include schemas/transactions.json
               example: !include examples/transactions.json
 
+  /targets/current-target:
+     is: [headers.acceptHeader, loginRequired, permissionOnAccountNinoRequired, ninoInvalid, mobileHelpToSaveShuttered]
+     put:
+       body:
+         application/json:
+           type: !include schemas/target.json
+           example: !include examples/target.json
+       displayName: Set a savings target for the user
+       description: Set a savings target for the user. This will replace any existing savings target.
+       (annotations.scope): "read:native-apps-api-orchestration"
+       securedBy: [ sec.oauth_2_0: { scopes: [ "read:native-apps-api-orchestration" ] } ]
+       responses:
+         204:
+         422:
+           body:
+             properties:
+               error:
+             example:
+               error: target amount should be in range 1 to 50
+     delete:
+       displayName: Remove the users' current savings target
+       description: Remove the users' current savings target
+       (annotations.scope): "read:native-apps-api-orchestration"
+       securedBy: [ sec.oauth_2_0: { scopes: [ "read:native-apps-api-orchestration" ] } ]
+       responses:
+         204:

--- a/resources/public/api/conf/1.0/examples/account.json
+++ b/resources/public/api/conf/1.0/examples/account.json
@@ -30,5 +30,9 @@
     }
   ],
   "currentBonusTerm": "First",
-  "inAppPaymentsEnabled": false
+  "inAppPaymentsEnabled": false,
+  "savingsTargetEnabled": true,
+  "savingsTarget": {
+    "targetAmount":21.50
+  }
 }

--- a/resources/public/api/conf/1.0/examples/target.json
+++ b/resources/public/api/conf/1.0/examples/target.json
@@ -1,0 +1,3 @@
+{
+  "targetAmount": 21.50
+}

--- a/resources/public/api/conf/1.0/schemas/target.json
+++ b/resources/public/api/conf/1.0/schemas/target.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "description": "The Help To Save account details",
+  "properties": {
+    "targetAmount": {
+      "type": "number",
+      "description": "The target amount that the user wants to save each month. This must be a number between 1 and the monthly savings limit (currently £50)",
+      "examples": [
+        21.50,
+        45
+      ]
+    }
+  },
+  "required": [
+    "targetAmount"
+  ]
+}


### PR DESCRIPTION
The API platform team have confirmed that we don't need to go through another api clinic to add the endpoints we want to add. This PR copies the 1.1 changes back to the 1.0 RAML and json schemas.

Once the frontend apps are changed back to using 1.0 then we should raise another ticket to delete the 1.1 RAML.