### PR TITLE
[BL][NGC-3818] Removing the invitationUrl 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ Response format:
   "supportFormEnabled": true,
   // URL of page containing information about the Help to Save scheme
   "infoUrl": "https://www.gov.uk/get-help-savings-low-income",
-  // URL of invitation call to action
-  "invitationUrl": "/mobile-help-to-save",
   // URL that will redirect enrolled users to the NS&I Help to Save account homepage
   "accessAccountUrl": "/mobile-help-to-save/access-account",
   // User-specific Help to Save data

--- a/app/uk/gov/hmrc/mobilehelptosave/config/MobileHelpToSaveConfig.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/config/MobileHelpToSaveConfig.scala
@@ -60,7 +60,6 @@ case class MobileHelpToSaveConfig @Inject()(
   override val supportFormEnabled        : Boolean = configBoolean("helpToSave.supportFormEnabled")
   override val inAppPaymentsEnabled      : Boolean = configBoolean("helpToSave.inAppPaymentsEnabled")
   override val helpToSaveInfoUrl         : String  = configString("helpToSave.infoUrl")
-  override val helpToSaveInvitationUrl   : String  = configString("helpToSave.invitationUrl")
   override val helpToSaveAccessAccountUrl: String  = configString("helpToSave.accessAccountUrl")
 
   private  val accessConfig                            = configuration.underlying.getConfig("api.access")
@@ -111,7 +110,6 @@ trait StartupControllerConfig {
   def shuttering: Shuttering
   def supportFormEnabled: Boolean
   def helpToSaveInfoUrl: String
-  def helpToSaveInvitationUrl: String
   def helpToSaveAccessAccountUrl: String
 }
 

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/StartupController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/StartupController.scala
@@ -38,7 +38,6 @@ class StartupController @Inject() (
         StartupResponse(
           shuttering = config.shuttering,
           infoUrl = Some(config.helpToSaveInfoUrl),
-          invitationUrl = Some(config.helpToSaveInvitationUrl),
           accessAccountUrl = Some(config.helpToSaveAccessAccountUrl),
           user = userOrError.right.toOption,
           userError = userOrError.left.toOption,
@@ -53,7 +52,6 @@ class StartupController @Inject() (
         StartupResponse(
           shuttering = config.shuttering,
           infoUrl = None,
-          invitationUrl = None,
           accessAccountUrl = None,
           user = None,
           userError = None,

--- a/app/uk/gov/hmrc/mobilehelptosave/domain/StartupResponse.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/domain/StartupResponse.scala
@@ -21,7 +21,6 @@ import play.api.libs.json._
 case class StartupResponse(
   shuttering: Shuttering,
   infoUrl: Option[String],
-  invitationUrl: Option[String],
   accessAccountUrl: Option[String],
   user: Option[UserDetails],
   userError: Option[ErrorInfo],

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -191,7 +191,6 @@ helpToSave {
   inAppPaymentsEnabled = false
   savingsGoalsEnabled = false
   infoUrl = "https://www.gov.uk/get-help-savings-low-income"
-  invitationUrl = "http://localhost:8249/mobile-help-to-save"
   accessAccountUrl = "http://localhost:8249/mobile-help-to-save/access-account"
   shuttering = {
     shuttered = false

--- a/it/uk/gov/hmrc/mobilehelptosave/StartupConfigISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/StartupConfigISpec.scala
@@ -81,7 +81,6 @@ class StartupConfigISpec extends WordSpec with Matchers with JsonMatchers with F
       response.status shouldBe 200
       (response.json \ "supportFormEnabled" ).validate[Boolean] should beJsSuccess
       (response.json \ "infoUrl").as[String] shouldBe "https://www.gov.uk/get-help-savings-low-income"
-      (response.json \ "invitationUrl").as[String] shouldBe "http://localhost:8249/mobile-help-to-save"
       (response.json \ "accessAccountUrl").as[String] shouldBe "http://localhost:8249/mobile-help-to-save/access-account"
     }
 
@@ -94,7 +93,6 @@ class StartupConfigISpec extends WordSpec with Matchers with JsonMatchers with F
         appBuilder
           .configure(
             "helpToSave.infoUrl" -> "http://www.example.com/test/help-to-save-information",
-            "helpToSave.invitationUrl" -> "http://www.example.com/test/help-to-save-invitation",
             "helpToSave.accessAccountUrl" -> "/access-account",
             "helpToSave.supportFormEnabled" -> "true"
           )
@@ -106,7 +104,6 @@ class StartupConfigISpec extends WordSpec with Matchers with JsonMatchers with F
         response.status shouldBe 200
         (response.json \ "supportFormEnabled").as[Boolean] shouldBe true
         (response.json \ "infoUrl").as[String] shouldBe "http://www.example.com/test/help-to-save-information"
-        (response.json \ "invitationUrl").as[String] shouldBe "http://www.example.com/test/help-to-save-invitation"
         (response.json \ "accessAccountUrl").as[String] shouldBe "/access-account"
       }
 

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/StartupControllerSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/StartupControllerSpec.scala
@@ -51,7 +51,6 @@ class StartupControllerSpec
     falseShuttering,
     supportFormEnabled = false,
     helpToSaveInfoUrl = "/info",
-    helpToSaveInvitationUrl = "/invitation",
     helpToSaveAccessAccountUrl = "/accessAccount"
   )
 
@@ -99,7 +98,6 @@ class StartupControllerSpec
         val jsonKeys = jsonBody.as[JsObject].keys
         jsonKeys should contain("user")
         (jsonBody \ "infoUrl").as[String] shouldBe "/info"
-        (jsonBody \ "invitationUrl").as[String] shouldBe "/invitation"
         (jsonBody \ "accessAccountUrl").as[String] shouldBe "/accessAccount"
       }
 
@@ -136,7 +134,6 @@ class StartupControllerSpec
         jsonKeys should not contain "user"
         (jsonBody \ "userError" \ "code").as[String] shouldBe "GENERAL"
         (jsonBody \ "infoUrl").as[String] shouldBe "/info"
-        (jsonBody \ "invitationUrl").as[String] shouldBe "/invitation"
         (jsonBody \ "accessAccountUrl").as[String] shouldBe "/accessAccount"
       }
     }
@@ -154,7 +151,6 @@ class StartupControllerSpec
         val jsonKeys = jsonBody.as[JsObject].keys
         jsonKeys should not contain "user"
         jsonKeys should not contain "infoUrl"
-        jsonKeys should not contain "invitationUrl"
         jsonKeys should not contain "accessAccountUrl"
       }
 
@@ -197,9 +193,7 @@ class StartupControllerSpec
 
 case class TestStartupControllerConfig(
   shuttering: Shuttering,
-
   supportFormEnabled: Boolean,
   helpToSaveInfoUrl: String,
-  helpToSaveInvitationUrl: String,
   helpToSaveAccessAccountUrl: String
 ) extends StartupControllerConfig


### PR DESCRIPTION
Post iOS/Android update this is no longer required