### PR TITLE
[DC][NGC-4254] Replace deprecated `MdcLoggingExecutionContext`

### DIFF
--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
@@ -34,7 +34,6 @@ import uk.gov.hmrc.mobilehelptosave.domain._
 import uk.gov.hmrc.mobilehelptosave.repository.{SavingsGoalMongoModel, SavingsGoalRepo}
 import uk.gov.hmrc.mobilehelptosave.services.AccountService
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
-import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext.fromLoggingDetails
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -54,7 +53,7 @@ class HelpToSaveController @Inject()
   authorisedWithIds: AuthorisedWithIds,
   config: HelpToSaveControllerConfig,
   savingsGoalRepo: SavingsGoalRepo
-) extends BaseController with ControllerChecks with HelpToSaveActions {
+)(implicit ec: ExecutionContext) extends BaseController with ControllerChecks with HelpToSaveActions {
 
   private final val AccountNotFound = NotFound(Json.toJson(ErrorBody("ACCOUNT_NOT_FOUND", "No Help to Save account exists for the specified NINO")))
 

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/StartupController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/StartupController.scala
@@ -23,14 +23,15 @@ import uk.gov.hmrc.mobilehelptosave.config.StartupControllerConfig
 import uk.gov.hmrc.mobilehelptosave.domain._
 import uk.gov.hmrc.mobilehelptosave.services.UserService
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
-import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext.fromLoggingDetails
+
+import scala.concurrent.ExecutionContext
 
 @Singleton()
-class StartupController @Inject() (
+class StartupController @Inject()(
   userService: UserService,
   authorisedWithIds: AuthorisedWithIds,
   config: StartupControllerConfig
-) extends BaseController {
+)(implicit ec: ExecutionContext) extends BaseController {
 
   val startup: Action[AnyContent] = if (!config.shuttering.shuttered) {
     authorisedWithIds.async { implicit request =>

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -15,7 +15,7 @@ object AppDependencies {
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc" %% "bootstrap-play-25" % "3.14.0" withSources(),
+    "uk.gov.hmrc" %% "bootstrap-play-25" % "4.0.0" withSources(),
     "uk.gov.hmrc" %% "domain" % "5.2.0",
     "org.typelevel" %% "cats-core" % "1.1.0",
     "io.lemonlabs" %% "scala-uri" % "1.1.1",

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/AuthorisedWithIdsSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/AuthorisedWithIdsSpec.scala
@@ -30,6 +30,7 @@ import uk.gov.hmrc.auth.core.retrieve.{Retrieval, Retrievals}
 import uk.gov.hmrc.domain.{Generator, Nino}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mobilehelptosave.support.LoggerStub
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/StartupControllerSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/StartupControllerSpec.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.mobilehelptosave.config.StartupControllerConfig
 import uk.gov.hmrc.mobilehelptosave.domain._
 import uk.gov.hmrc.mobilehelptosave.services.UserService
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
 class StartupControllerSpec
@@ -40,11 +41,11 @@ class StartupControllerSpec
   private implicit val hc: HeaderCarrier = HeaderCarrier()
 
   private val generator = new Generator(0)
-  private val nino = generator.nextNino
+  private val nino      = generator.nextNino
 
   private val mockUserService = mock[UserService]
 
-  private val trueShuttering = Shuttering(shuttered = true, "Shuttered", "HTS is currently not available")
+  private val trueShuttering  = Shuttering(shuttered = true, "Shuttered", "HTS is currently not available")
   private val falseShuttering = Shuttering(shuttered = false, "", "")
 
   private val config = TestStartupControllerConfig(

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/GetAccountSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/GetAccountSpec.scala
@@ -32,6 +32,8 @@ import uk.gov.hmrc.mobilehelptosave.services.AccountService
 import uk.gov.hmrc.mobilehelptosave.support.LoggerStub
 import uk.gov.hmrc.mobilehelptosave.{AccountTestData, TransactionTestData}
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 //noinspection TypeAnnotation
 class GetAccountSpec
   extends WordSpec

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/GetTransactionsSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/GetTransactionsSpec.scala
@@ -30,6 +30,7 @@ import uk.gov.hmrc.mobilehelptosave.services.AccountService
 import uk.gov.hmrc.mobilehelptosave.support.LoggerStub
 import uk.gov.hmrc.mobilehelptosave.{AccountTestData, TransactionTestData}
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 //noinspection TypeAnnotation

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/TestSupport.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/TestSupport.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.mobilehelptosave.repository.{SavingsGoalMongoModel, SavingsGo
 import uk.gov.hmrc.mobilehelptosave.services.AccountService
 import uk.gov.hmrc.mobilehelptosave.support.LoggerStub
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
 case class TestHelpToSaveControllerConfig(shuttering: Shuttering, savingsGoalsEnabled: Boolean)


### PR DESCRIPTION
I've upgraded `play-bootstrap-25` to version `4.0.0`. This version deprecates `MdcLoggingExecutionContext` and replaces it with an `ExecutionContext` that can be injected via guice and does the work of carrying the log context through the call stack. See https://confluence.tools.tax.service.gov.uk/x/HYhsC for more details.