### PR TITLE
[DC][NGC-4140] I have fixed a bug with the `PUT` call that sets the u…

### DIFF
--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
@@ -16,9 +16,6 @@
 
 package uk.gov.hmrc.mobilehelptosave.controllers
 
-
-import java.time.LocalDateTime
-
 import cats.instances.future._
 import cats.syntax.apply._
 import javax.inject.{Inject, Singleton}
@@ -126,7 +123,7 @@ class HelpToSaveController @Inject()
       Future.successful(UnprocessableEntity(obj("error" -> s"goal amount should be in range 1 to $maxGoal")))
     else
       savingsGoalRepo
-        .put(SavingsGoalMongoModel(verifiedUserNino.nino, request.body.goalAmount, LocalDateTime.now))
+        .setGoal(verifiedUserNino, request.body.goalAmount)
         .recover {
           case t => logger.error("error writing savings goal to mongo", t)
         }

--- a/app/uk/gov/hmrc/mobilehelptosave/repository/NinoIndexedMongoRepo.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/repository/NinoIndexedMongoRepo.scala
@@ -41,8 +41,8 @@ class NinoIndexedMongoRepo[T](
     Index(Seq("nino" -> IndexType.Text), name = Some("ninoIdx"), unique = true, sparse = true)
   )
 
-  def put(flags: T): Future[Unit] =
-    insert(flags).void
+  def put(t: T): Future[Unit] =
+    insert(t).void
 
   def get(nino: Nino): Future[Option[T]] =
     find("nino" -> nino.value).map(_.headOption)

--- a/app/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalRepo.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalRepo.scala
@@ -24,6 +24,7 @@ import scala.concurrent.Future
 @ImplementedBy(classOf[MongoSavingsGoalRepo])
 trait SavingsGoalRepo {
   def put(savingsGoal: SavingsGoalMongoModel): Future[Unit]
+  def setGoal(nino: Nino, value: Double): Future[Unit]
   def get(nino: Nino): Future[Option[SavingsGoalMongoModel]]
   def delete(nino: Nino): Future[Unit]
 }

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/SavingsGoalSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/SavingsGoalSpec.scala
@@ -42,12 +42,12 @@ class SavingsGoalSpec
 {
   "putSavingsGoal" when {
     "logged in user's NINO matches NINO in URL" should {
-      "return put the goal value in the repo and respond with 204" in new AuthorisedTestScenario with HelpToSaveMocking {
+      "set the goal value in the repo and respond with 204" in new AuthorisedTestScenario with HelpToSaveMocking {
         val amount  = 21.50
         val request = FakeRequest().withBody(SavingsGoal(amount))
 
         accountReturns(Right(Some(mobileHelpToSaveAccount)))
-        putSavingsGoalExpects(nino.value, amount)
+        setSavingsGoalExpects(nino.value, amount)
         val resultF = controller.putSavingsGoal(nino.value)(request)
 
         status(resultF) shouldBe 204

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/TestSupport.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/TestSupport.scala
@@ -91,9 +91,9 @@ trait TestSupport {
         .returning(stubbedResponse)
     }
 
-    def putSavingsGoalExpects(nino: String, amount: Double) = {
-      (savingsGoalRepo.put(_: SavingsGoalMongoModel))
-        .expects(where { st: SavingsGoalMongoModel => st.nino == nino && st.amount == amount })
+    def setSavingsGoalExpects(expectedNino: String, expectedAmount: Double) = {
+      (savingsGoalRepo.setGoal(_: Nino, _: Double))
+        .expects(where { (nino, amount) => nino.nino == expectedNino && amount == expectedAmount })
         .returning(Future.successful(()))
     }
 


### PR DESCRIPTION
…ser's goal. If the goal was already set then the new goal would fail to be set (because I didn't understand how to use the reactive mongo api!). It should now work fine.

This has left a little bit of tech debt in the structure of `NinoIndexedMongoRepo` as `MongoSavingsGoalRepo` now implements a specific call to update the document and there may be some opportunity to generalise it.