### PR TITLE
Reverted to `play-reactivemongo` 6.2.0 because of issues with the dow…

### DIFF
--- a/app/uk/gov/hmrc/mobilehelptosave/repository/NinoIndexedMongoRepo.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/repository/NinoIndexedMongoRepo.scala
@@ -32,8 +32,8 @@ import scala.concurrent.{ExecutionContext, Future}
   * Want to store something in Mongo indexed against a NINO? Just create the model for the
   * data and subclass this handy helper.
   */
-class NinoIndexedMongoRepo[T](
-  collectionName:String,
+class NinoIndexedMongoRepo[T: Manifest](
+  collectionName: String,
   val reactiveMongo: Provider[ReactiveMongoComponent]
 )(implicit ec: ExecutionContext, mongoFormats: Format[T])
   extends ReactiveRepository[T, BSONObjectID](collectionName, reactiveMongo.get().mongoConnector.db, mongoFormats) {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,18 +10,16 @@ object AppDependencies {
     resolvers += "emueller-bintray" at "http://dl.bintray.com/emueller/maven"
   )
 
-  private val reactiveMongoVersion = "7.4.0-play-25"
-  private val microserviceAsyncVersion = "2.2.0"
+  private val reactiveMongoVersion = "6.2.0"
 
-  val compile = Seq(
+  val compile: Seq[ModuleID] = Seq(
     ws,
     "uk.gov.hmrc" %% "bootstrap-play-25" % "4.0.0" withSources(),
     "uk.gov.hmrc" %% "domain" % "5.2.0",
     "org.typelevel" %% "cats-core" % "1.1.0",
     "io.lemonlabs" %% "scala-uri" % "1.1.1",
-    "uk.gov.hmrc" %% "play-hmrc-api" % "3.0.0",
-    "uk.gov.hmrc" %% "simple-reactivemongo" % reactiveMongoVersion,
-    "uk.gov.hmrc" %% "microservice-async" % microserviceAsyncVersion
+    "uk.gov.hmrc" %% "play-hmrc-api" % "3.3.0-play-25",
+    "uk.gov.hmrc" %% "play-reactivemongo" % reactiveMongoVersion
   )
 
   val test: Seq[ModuleID] = testCommon("test") ++ Seq(
@@ -32,7 +30,7 @@ object AppDependencies {
     "com.github.tomakehurst" % "wiremock" % "2.19.0" % "it"
   )
 
-  def testCommon(scope: String) = Seq(
+  def testCommon(scope: String): Seq[ModuleID] = Seq(
     "org.scalatest" %% "scalatest" % "3.0.5" % scope,
     "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.1" % scope,
     "org.pegdown" % "pegdown" % "1.6.0" % scope,


### PR DESCRIPTION
…nstream `reactivemongo` dependency that was causing re-connect problems after the mongdb server restarts.