### PR TITLE
[NGC-3042] If there is an error accessing the mongo repo to get the s…

### DIFF
--- a/app/uk/gov/hmrc/mobilehelptosave/config/MobileHelpToSaveConfig.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/config/MobileHelpToSaveConfig.scala
@@ -82,6 +82,7 @@ case class MobileHelpToSaveConfig @Inject()(
 @ImplementedBy(classOf[MobileHelpToSaveConfig])
 trait AccountServiceConfig {
   def inAppPaymentsEnabled: Boolean
+  def savingsGoalsEnabled: Boolean
 }
 
 @ImplementedBy(classOf[MobileHelpToSaveConfig])

--- a/testcommon/uk/gov/hmrc/mobilehelptosave/AccountTestData.scala
+++ b/testcommon/uk/gov/hmrc/mobilehelptosave/AccountTestData.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.mobilehelptosave
 
 import org.joda.time.{LocalDate, YearMonth}
 import uk.gov.hmrc.mobilehelptosave.connectors.{HelpToSaveAccount, HelpToSaveBonusTerm}
-import uk.gov.hmrc.mobilehelptosave.domain.{Account, Blocking, BonusTerm, CurrentBonusTerm}
+import uk.gov.hmrc.mobilehelptosave.domain._
 
 trait AccountTestData {
 
@@ -154,7 +154,9 @@ trait AccountTestData {
     currentBonusTerm = CurrentBonusTerm.First,
     closureDate = None,
     closingBalance = None,
-    inAppPaymentsEnabled = false
+    inAppPaymentsEnabled = false,
+    savingsGoalsEnabled = true,
+    savingsGoal = None
   )
 
   protected val closedAccountReturnedByHelpToSaveJsonString: String =


### PR DESCRIPTION
…avings goal then this will be reflected as a 500 response from the api call, the same as if there is an error calling NS&I to get the main account data. To deal with this I have re-worked things so that it is the `AccountService` that calls both the NS&I connector and the mongo repo to collect the account data and merges it. The controller now just makes a single call to the `AccountService` and doesn't need to know that the savings goal is held separately.