### PR TITLE
Generic indexed repo

### DIFF
--- a/app/uk/gov/hmrc/mobilehelptosave/config/MobileHelpToSaveConfig.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/config/MobileHelpToSaveConfig.scala
@@ -117,5 +117,4 @@ trait StartupControllerConfig {
 @ImplementedBy(classOf[MobileHelpToSaveConfig])
 trait HelpToSaveControllerConfig {
   def shuttering: Shuttering
-  def savingsGoalsEnabled: Boolean
 }

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
@@ -102,8 +102,8 @@ class HelpToSaveController @Inject()
 
   def deleteSavingsGoal(nino: String): Action[AnyContent] =
     authorisedWithIds.async { implicit request: RequestWithIds[AnyContent] =>
-      verifyingMatchingNino(config.shuttering, nino) { nino =>
-        savingsGoalRepo.delete(nino).map(_ => NoContent)
+      verifyingMatchingNino(config.shuttering, nino) {
+        savingsGoalRepo.delete(_).map(_ => NoContent)
       }
     }
 }

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
@@ -96,7 +96,7 @@ class HelpToSaveController @Inject()
       Future.successful(UnprocessableEntity(obj("error" -> s"goal amount should be in range 1 to $maxGoal")))
     else
       savingsGoalRepo
-        .set(verifiedUserNino, SavingsGoalMongoModel(verifiedUserNino.nino, request.body.goalAmount, LocalDateTime.now))
+        .setGoal(SavingsGoalMongoModel(verifiedUserNino, request.body.goalAmount, LocalDateTime.now))
         .recover {
           case t => logger.error("error writing savings goal to mongo", t)
         }

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
@@ -69,11 +69,10 @@ class HelpToSaveController @Inject()
       accountService.account(nino).map {
         case Left(errorInfo)      => InternalServerError(Json.toJson(errorInfo))
         case Right(None)          => AccountNotFound
-        case Right(Some(account)) => Ok(Json.toJson(account.copy(savingsGoalsEnabled = config.savingsGoalsEnabled)))
+        case Right(Some(account)) => Ok(Json.toJson(account))
       }
     }
   }
-
 
   def putSavingsGoal(ninoString: String): Action[SavingsGoal] =
     authorisedWithIds.async(parse.json[SavingsGoal]) { implicit request: RequestWithIds[SavingsGoal] =>

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
@@ -16,8 +16,6 @@
 
 package uk.gov.hmrc.mobilehelptosave.controllers
 
-import java.time.LocalDateTime
-
 import javax.inject.{Inject, Singleton}
 import play.api.LoggerLike
 import play.api.libs.json.Json
@@ -27,7 +25,7 @@ import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.mobilehelptosave.config.HelpToSaveControllerConfig
 import uk.gov.hmrc.mobilehelptosave.connectors.HelpToSaveGetTransactions
 import uk.gov.hmrc.mobilehelptosave.domain._
-import uk.gov.hmrc.mobilehelptosave.repository.{SavingsGoalMongoModel, SavingsGoalRepo}
+import uk.gov.hmrc.mobilehelptosave.repository.SavingsGoalRepo
 import uk.gov.hmrc.mobilehelptosave.services.AccountService
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
 
@@ -95,7 +93,7 @@ class HelpToSaveController @Inject()
       Future.successful(UnprocessableEntity(obj("error" -> s"goal amount should be in range 1 to $maxGoal")))
     else
       savingsGoalRepo
-        .setGoal(SavingsGoalMongoModel(verifiedUserNino, request.body.goalAmount, LocalDateTime.now))
+        .setGoal(verifiedUserNino, request.body.goalAmount)
         .recover {
           case t => logger.error("error writing savings goal to mongo", t)
         }

--- a/app/uk/gov/hmrc/mobilehelptosave/repository/MongoSavingsGoalRepo.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/repository/MongoSavingsGoalRepo.scala
@@ -23,9 +23,9 @@ import play.api.libs.json.{Format, Json, OWrites, Reads}
 import play.modules.reactivemongo.ReactiveMongoComponent
 import uk.gov.hmrc.domain.Nino
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
-case class SavingsGoalMongoModel(nino: String, amount: Double, createdAt: LocalDateTime)
+case class SavingsGoalMongoModel(nino: Nino, amount: Double, createdAt: LocalDateTime)
 
 object SavingsGoalMongoModel {
   implicit val reads : Reads[SavingsGoalMongoModel]   = Json.reads[SavingsGoalMongoModel]
@@ -40,4 +40,7 @@ class MongoSavingsGoalRepo @Inject()(
 )
   (implicit ec: ExecutionContext, mongoFormats: Format[SavingsGoalMongoModel])
   extends IndexedMongoRepo[Nino, SavingsGoalMongoModel]("savingsGoals", "nino", reactiveMongo)
-    with SavingsGoalRepo
+    with SavingsGoalRepo {
+
+  override def setGoal(savingsGoal: SavingsGoalMongoModel): Future[Unit] = set(savingsGoal)(_.nino)
+}

--- a/app/uk/gov/hmrc/mobilehelptosave/repository/MongoSavingsGoalRepo.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/repository/MongoSavingsGoalRepo.scala
@@ -42,5 +42,5 @@ class MongoSavingsGoalRepo @Inject()(
   extends IndexedMongoRepo[Nino, SavingsGoalMongoModel]("savingsGoals", "nino", reactiveMongo)
     with SavingsGoalRepo {
 
-  override def setGoal(savingsGoal: SavingsGoalMongoModel): Future[Unit] = set(savingsGoal)(_.nino)
+  override def setGoal(nino: Nino, amount: Double): Future[Unit] = set(SavingsGoalMongoModel(nino, amount, LocalDateTime.now))(_.nino)
 }

--- a/app/uk/gov/hmrc/mobilehelptosave/repository/MongoSavingsGoalRepo.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/repository/MongoSavingsGoalRepo.scala
@@ -18,15 +18,12 @@ package uk.gov.hmrc.mobilehelptosave.repository
 
 import java.time.LocalDateTime
 
-import cats.instances.future._
-import cats.syntax.functor._
 import javax.inject.{Inject, Provider}
-import play.api.libs.json.Json._
 import play.api.libs.json.{Format, Json, OWrites, Reads}
 import play.modules.reactivemongo.ReactiveMongoComponent
 import uk.gov.hmrc.domain.Nino
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 case class SavingsGoalMongoModel(nino: String, amount: Double, createdAt: LocalDateTime)
 
@@ -42,14 +39,5 @@ class MongoSavingsGoalRepo @Inject()(
   override val reactiveMongo: Provider[ReactiveMongoComponent]
 )
   (implicit ec: ExecutionContext, mongoFormats: Format[SavingsGoalMongoModel])
-  extends NinoIndexedMongoRepo[SavingsGoalMongoModel]("savingsGoals", reactiveMongo)
-    with SavingsGoalRepo {
-
-  override def setGoal(nino: Nino, value: Double): Future[Unit] = {
-    findAndUpdate(
-      obj("nino" -> nino),
-      obj("$set" -> obj("amount" -> value, "createdAt" -> LocalDateTime.now())),
-      upsert = true
-    ).void
-  }
-}
+  extends IndexedMongoRepo[Nino, SavingsGoalMongoModel]("savingsGoals", "nino", reactiveMongo)
+    with SavingsGoalRepo

--- a/app/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalRepo.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalRepo.scala
@@ -23,7 +23,6 @@ import scala.concurrent.Future
 
 @ImplementedBy(classOf[MongoSavingsGoalRepo])
 trait SavingsGoalRepo {
-  def put(savingsGoal: SavingsGoalMongoModel): Future[Unit]
   def set(nino: Nino, savingsGoal: SavingsGoalMongoModel): Future[Unit]
   def get(nino: Nino): Future[Option[SavingsGoalMongoModel]]
   def delete(nino: Nino): Future[Unit]

--- a/app/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalRepo.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalRepo.scala
@@ -24,7 +24,7 @@ import scala.concurrent.Future
 @ImplementedBy(classOf[MongoSavingsGoalRepo])
 trait SavingsGoalRepo {
   def put(savingsGoal: SavingsGoalMongoModel): Future[Unit]
-  def setGoal(nino: Nino, value: Double): Future[Unit]
+  def set(nino: Nino, savingsGoal: SavingsGoalMongoModel): Future[Unit]
   def get(nino: Nino): Future[Option[SavingsGoalMongoModel]]
   def delete(nino: Nino): Future[Unit]
 }

--- a/app/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalRepo.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalRepo.scala
@@ -23,7 +23,7 @@ import scala.concurrent.Future
 
 @ImplementedBy(classOf[MongoSavingsGoalRepo])
 trait SavingsGoalRepo {
-  def set(nino: Nino, savingsGoal: SavingsGoalMongoModel): Future[Unit]
+  def setGoal(savingsGoal: SavingsGoalMongoModel): Future[Unit]
   def get(nino: Nino): Future[Option[SavingsGoalMongoModel]]
   def delete(nino: Nino): Future[Unit]
 }

--- a/app/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalRepo.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalRepo.scala
@@ -23,7 +23,7 @@ import scala.concurrent.Future
 
 @ImplementedBy(classOf[MongoSavingsGoalRepo])
 trait SavingsGoalRepo {
-  def setGoal(savingsGoal: SavingsGoalMongoModel): Future[Unit]
+  def setGoal(nino: Nino, amount:Double): Future[Unit]
   def get(nino: Nino): Future[Option[SavingsGoalMongoModel]]
   def delete(nino: Nino): Future[Unit]
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -32,6 +32,7 @@ object AppDependencies {
 
   def testCommon(scope: String): Seq[ModuleID] = Seq(
     "org.scalatest" %% "scalatest" % "3.0.5" % scope,
+    "org.scalacheck" %% "scalacheck" % "1.14.0" % scope,
     "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.1" % scope,
     "org.pegdown" % "pegdown" % "1.6.0" % scope,
     "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/SandboxControllerSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/SandboxControllerSpec.scala
@@ -54,7 +54,7 @@ class SandboxControllerSpec
   private val nino = generator.nextNino
   private val shuttering = Shuttering(shuttered = false, "", "")
   private val shutteredShuttering = Shuttering(shuttered = true, "Gad Dangit!", "This service is shuttered")
-  private val config = TestHelpToSaveControllerConfig(shuttering, savingsGoalsEnabled = false)
+  private val config = TestHelpToSaveControllerConfig(shuttering)
   private val currentTime = new DateTime(2018, 9, 29, 12, 30, DateTimeZone.forID("Europe/London"))
   private val fixedClock = new FixedFakeClock(currentTime)
   private val controller: SandboxController = new SandboxController(logger, config, SandboxData(logger, fixedClock, TestSandboxDataConfig))

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/GetAccountSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/GetAccountSpec.scala
@@ -64,7 +64,7 @@ class GetAccountSpec
         val accountData = controller.getAccount(nino.value)(FakeRequest())
         status(accountData) shouldBe OK
         val jsonBody = contentAsJson(accountData)
-        jsonBody shouldBe Json.toJson(mobileHelpToSaveAccount.copy(savingsGoalsEnabled = config.savingsGoalsEnabled))
+        jsonBody shouldBe Json.toJson(mobileHelpToSaveAccount)
       }
     }
 
@@ -149,37 +149,6 @@ class GetAccountSpec
         (jsonBody \ "shuttered").as[Boolean] shouldBe true
         (jsonBody \ "title").as[String] shouldBe "Shuttered"
         (jsonBody \ "message").as[String] shouldBe "HTS is currently not available"
-      }
-    }
-
-    "the savingsGoalsEnabled flag configured as true" should {
-      "return true in the Account" in new AuthorisedTestScenario with HelpToSaveMocking {
-        accountReturns(Right(Some(mobileHelpToSaveAccount)))
-
-        override val controller =
-          new HelpToSaveController(
-            logger,
-            accountService,
-            helpToSaveGetTransactions,
-            new AlwaysAuthorisedWithIds(nino),
-            config.copy(savingsGoalsEnabled = true),
-            savingsGoalRepo)
-
-        val accountData = controller.getAccount(nino.value)(FakeRequest())
-        status(accountData) shouldBe OK
-        val jsonBody = contentAsJson(accountData)
-        (jsonBody \ "savingsGoalsEnabled").as[Boolean] shouldBe true
-      }
-    }
-
-    "the savingsGoalsEnabled flag is configured as false" should {
-      "return false in the Account" in new AuthorisedTestScenario with HelpToSaveMocking {
-        accountReturns(Right(Some(mobileHelpToSaveAccount)))
-
-        val accountData = controller.getAccount(nino.value)(FakeRequest())
-        status(accountData) shouldBe OK
-        val jsonBody = contentAsJson(accountData)
-        (jsonBody \ "savingsGoalsEnabled").as[Boolean] shouldBe false
       }
     }
   }

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/SavingsGoalSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/SavingsGoalSpec.scala
@@ -47,7 +47,7 @@ class SavingsGoalSpec
         val request = FakeRequest().withBody(SavingsGoal(amount))
 
         accountReturns(Right(Some(mobileHelpToSaveAccount)))
-        setSavingsGoalExpects(nino.value, amount)
+        setSavingsGoalExpects(nino, amount)
         val resultF = controller.putSavingsGoal(nino.value)(request)
 
         status(resultF) shouldBe 204

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/TestSupport.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/TestSupport.scala
@@ -92,8 +92,8 @@ trait TestSupport {
     }
 
     def setSavingsGoalExpects(expectedNino: Nino, expectedAmount: Double) = {
-      (savingsGoalRepo.setGoal(_: SavingsGoalMongoModel))
-        .expects(where { model: SavingsGoalMongoModel => model.nino == expectedNino && model.amount == expectedAmount })
+      (savingsGoalRepo.setGoal(_: Nino, _: Double))
+        .expects(where { (nino, amount) => nino == expectedNino && amount == expectedAmount })
         .returning(Future.successful(()))
     }
 

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/TestSupport.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/TestSupport.scala
@@ -92,8 +92,8 @@ trait TestSupport {
     }
 
     def setSavingsGoalExpects(expectedNino: Nino, expectedAmount: Double) = {
-      (savingsGoalRepo.set(_: Nino, _: SavingsGoalMongoModel))
-        .expects(where { (nino, model) => nino == expectedNino && model.nino == expectedNino.nino && model.amount == expectedAmount })
+      (savingsGoalRepo.setGoal(_: SavingsGoalMongoModel))
+        .expects(where { model: SavingsGoalMongoModel => model.nino == expectedNino && model.amount == expectedAmount })
         .returning(Future.successful(()))
     }
 

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/TestSupport.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/TestSupport.scala
@@ -91,9 +91,9 @@ trait TestSupport {
         .returning(stubbedResponse)
     }
 
-    def setSavingsGoalExpects(expectedNino: String, expectedAmount: Double) = {
-      (savingsGoalRepo.setGoal(_: Nino, _: Double))
-        .expects(where { (nino, amount) => nino.nino == expectedNino && amount == expectedAmount })
+    def setSavingsGoalExpects(expectedNino: Nino, expectedAmount: Double) = {
+      (savingsGoalRepo.set(_: Nino, _: SavingsGoalMongoModel))
+        .expects(where { (nino, model) => nino == expectedNino && model.nino == expectedNino.nino && model.amount == expectedAmount })
         .returning(Future.successful(()))
     }
 

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/TestSupport.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/TestSupport.scala
@@ -31,7 +31,7 @@ import uk.gov.hmrc.mobilehelptosave.support.LoggerStub
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
-case class TestHelpToSaveControllerConfig(shuttering: Shuttering, savingsGoalsEnabled: Boolean)
+case class TestHelpToSaveControllerConfig(shuttering: Shuttering)
   extends HelpToSaveControllerConfig
 
 //noinspection TypeAnnotation
@@ -46,7 +46,7 @@ trait TestSupport {
   val trueShuttering  = Shuttering(shuttered = true, "Shuttered", "HTS is currently not available")
   val falseShuttering = Shuttering(shuttered = false, "", "")
 
-  val config = TestHelpToSaveControllerConfig(falseShuttering, savingsGoalsEnabled = false)
+  val config = TestHelpToSaveControllerConfig(falseShuttering)
 
   def isForbiddenIfNotAuthorisedForUser(authorisedActionForNino: HelpToSaveController => Assertion): Assertion = {
     val accountService = mock[AccountService]

--- a/test/uk/gov/hmrc/mobilehelptosave/services/HelpToSaveAccountServiceSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/services/HelpToSaveAccountServiceSpec.scala
@@ -128,10 +128,6 @@ class HelpToSaveAccountServiceSpec extends WordSpec with Matchers
   private val fUnit = Future.successful(())
 
   private def fakeSavingsGoalRepo(expectedNino: Nino, goalOrException: Either[Throwable, Option[SavingsGoalMongoModel]]): SavingsGoalRepo = new SavingsGoalRepo {
-    override def put(savingsGoal: SavingsGoalMongoModel): Future[Unit] = {
-      nino shouldBe expectedNino
-      fUnit
-    }
     override def set(nino: Nino, savingsGoalMongoModel: SavingsGoalMongoModel): Future[Unit] = {
       nino shouldBe expectedNino
       fUnit

--- a/test/uk/gov/hmrc/mobilehelptosave/services/HelpToSaveAccountServiceSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/services/HelpToSaveAccountServiceSpec.scala
@@ -132,7 +132,7 @@ class HelpToSaveAccountServiceSpec extends WordSpec with Matchers
       nino shouldBe expectedNino
       fUnit
     }
-    override def setGoal(nino: Nino, value: Double): Future[Unit] = {
+    override def set(nino: Nino, savingsGoalMongoModel: SavingsGoalMongoModel): Future[Unit] = {
       nino shouldBe expectedNino
       fUnit
     }

--- a/test/uk/gov/hmrc/mobilehelptosave/services/HelpToSaveAccountServiceSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/services/HelpToSaveAccountServiceSpec.scala
@@ -108,7 +108,7 @@ class HelpToSaveAccountServiceSpec
       }
 
       val fakeGoalRepo = new SavingsGoalRepo {
-        override def setGoal(savingsGoal: SavingsGoalMongoModel): Future[Unit] = fail("setGoal should not have been called")
+        override def setGoal(nino: Nino, amount: Double): Future[Unit] = fail("setGoal should not have been called")
         override def get(nino: Nino): Future[Option[SavingsGoalMongoModel]] = fail("get should not have been called")
         override def delete(nino: Nino): Future[Unit] = fail("delete should not have been called")
       }
@@ -167,7 +167,7 @@ class HelpToSaveAccountServiceSpec
   private val fUnit = Future.successful(())
 
   private def fakeSavingsGoalRepo(expectedNino: Nino, goalOrException: Either[Throwable, Option[SavingsGoalMongoModel]]): SavingsGoalRepo = new SavingsGoalRepo {
-    override def setGoal(savingsGoalMongoModel: SavingsGoalMongoModel): Future[Unit] = {
+    override def setGoal(nino: Nino, amount: Double): Future[Unit] = {
       nino shouldBe expectedNino
       fUnit
     }


### PR DESCRIPTION
The main change here is to add a second type parameter to `IndexedMongoRepo` to represent the type of the index field, and change the `set` method appropriately.

In addition, there is some re-factoring of `AccountService` to help with testing.