### PR TITLE
I've rolled back to `play-reactivemongo` 6.1.0 and re-implemented the…

### DIFF
--- a/app/uk/gov/hmrc/mobilehelptosave/connectors/HelpToSaveConnector.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/connectors/HelpToSaveConnector.scala
@@ -28,7 +28,6 @@ import play.api.libs.json._
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.mobilehelptosave.config.HelpToSaveConnectorConfig
-import uk.gov.hmrc.mobilehelptosave.config.ScalaUriConfig.config
 import uk.gov.hmrc.mobilehelptosave.config.SystemId.SystemId
 import uk.gov.hmrc.mobilehelptosave.domain._
 import uk.gov.hmrc.play.encoding.UriPathEncoding.encodePathSegment

--- a/app/uk/gov/hmrc/mobilehelptosave/repository/IndexedMongoRepo.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/repository/IndexedMongoRepo.scala
@@ -61,17 +61,10 @@ class IndexedMongoRepo[I, V: Manifest](
     *                then this is probably just a function to extract that index value.
     */
   def set(value: V)(indexOf: V => I)(implicit ec: ExecutionContext): Future[Unit] = {
-    val indexValue = Json.toJson(indexOf(value))
-    val lookup: BSONDocument = BSONDocument(indexFieldName -> indexValue)
-    val modifier: BSONDocument = BSONDocument("$set" -> Json.toJson(value))
-    atomicUpdate(lookup, modifier).void
-
-    //    findAndUpdate(
-    //      obj(indexFieldName -> indexOf(lookup)),
-    //      obj("$set" -> Json.toJson(lookup)),
-    //      upsert = true
-    //    ).void
-
+    atomicUpdate(
+      BSONDocument(indexFieldName -> Json.toJson(indexOf(value))),
+      BSONDocument("$set" -> Json.toJson(value))
+    ).void
   }
 
   override def isInsertion(newRecordId: BSONObjectID, oldRecord: V): Boolean = false

--- a/app/uk/gov/hmrc/mobilehelptosave/repository/MongoSavingsGoalRepo.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/repository/MongoSavingsGoalRepo.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.mobilehelptosave.repository
 
 import java.time.LocalDateTime
 
-import javax.inject.{Inject, Provider}
+import javax.inject.Inject
 import play.api.libs.json.{Format, Json, OWrites, Reads}
 import play.modules.reactivemongo.ReactiveMongoComponent
 import uk.gov.hmrc.domain.Nino
@@ -36,10 +36,10 @@ object SavingsGoalMongoModel {
 }
 
 class MongoSavingsGoalRepo @Inject()(
-  override val reactiveMongo: Provider[ReactiveMongoComponent]
+  mongo: ReactiveMongoComponent
 )
   (implicit ec: ExecutionContext, mongoFormats: Format[SavingsGoalMongoModel])
-  extends IndexedMongoRepo[Nino, SavingsGoalMongoModel]("savingsGoals", "nino", reactiveMongo)
+  extends IndexedMongoRepo[Nino, SavingsGoalMongoModel]("savingsGoals", "nino", mongo)
     with SavingsGoalRepo {
 
   override def setGoal(nino: Nino, amount: Double): Future[Unit] = set(SavingsGoalMongoModel(nino, amount, LocalDateTime.now))(_.nino)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,7 +10,7 @@ object AppDependencies {
     resolvers += "emueller-bintray" at "http://dl.bintray.com/emueller/maven"
   )
 
-  private val reactiveMongoVersion = "7.7.0-play-25"
+  private val reactiveMongoVersion = "6.1.0"
 
   val compile: Seq[ModuleID] = Seq(
     ws,
@@ -19,7 +19,7 @@ object AppDependencies {
     "org.typelevel" %% "cats-core" % "1.1.0",
     "io.lemonlabs" %% "scala-uri" % "1.1.1",
     "uk.gov.hmrc" %% "play-hmrc-api" % "3.3.0-play-25",
-    "uk.gov.hmrc" %% "simple-reactivemongo" % reactiveMongoVersion
+    "uk.gov.hmrc" %% "play-reactivemongo" % reactiveMongoVersion
   )
 
   val test: Seq[ModuleID] = testCommon("test") ++ Seq(


### PR DESCRIPTION
… `IndexedMongoRepo.set` method using `AtomicUpdate` to mitigate the performance issues that have been identified with the later versions of the underlying `reactivemongo` library