### PR TITLE
Move delete and get events into the `AccountService`

### DIFF
--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
@@ -19,11 +19,10 @@ package uk.gov.hmrc.mobilehelptosave.controllers
 import javax.inject.{Inject, Singleton}
 import play.api.LoggerLike
 import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent}
+import play.api.mvc.{Action, AnyContent, Result}
 import uk.gov.hmrc.mobilehelptosave.config.HelpToSaveControllerConfig
 import uk.gov.hmrc.mobilehelptosave.connectors.HelpToSaveGetTransactions
 import uk.gov.hmrc.mobilehelptosave.domain._
-import uk.gov.hmrc.mobilehelptosave.repository.SavingsGoalEventRepo
 import uk.gov.hmrc.mobilehelptosave.services.AccountService
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
 
@@ -44,8 +43,7 @@ class HelpToSaveController @Inject()
   accountService: AccountService,
   helpToSaveGetTransactions: HelpToSaveGetTransactions,
   authorisedWithIds: AuthorisedWithIds,
-  config: HelpToSaveControllerConfig,
-  savingsGoalEventRepo: SavingsGoalEventRepo
+  config: HelpToSaveControllerConfig
 )(implicit ec: ExecutionContext) extends BaseController with ControllerChecks with HelpToSaveActions {
 
   private final val AccountNotFound = NotFound(Json.toJson(ErrorBody("ACCOUNT_NOT_FOUND", "No Help to Save account exists for the specified NINO")))
@@ -54,9 +52,10 @@ class HelpToSaveController @Inject()
     authorisedWithIds.async { implicit request: RequestWithIds[AnyContent] =>
       verifyingMatchingNino(config.shuttering, ninoString) { verifiedUserNino =>
         helpToSaveGetTransactions.getTransactions(verifiedUserNino).map {
-          case Right(Some(transactions)) => Ok(Json.toJson(transactions.reverse))
-          case Right(None)               => AccountNotFound
-          case Left(errorInfo)           => InternalServerError(Json.toJson(errorInfo))
+          handlingErrors {
+            case Some(transactions) => Ok(Json.toJson(transactions.reverse))
+            case None               => AccountNotFound
+          }
         }
       }
     }
@@ -64,9 +63,10 @@ class HelpToSaveController @Inject()
   override def getAccount(ninoString: String): Action[AnyContent] = authorisedWithIds.async { implicit request: RequestWithIds[AnyContent] =>
     verifyingMatchingNino(config.shuttering, ninoString) { nino =>
       accountService.account(nino).map {
-        case Left(errorInfo)      => InternalServerError(Json.toJson(errorInfo))
-        case Right(None)          => AccountNotFound
-        case Right(Some(account)) => Ok(Json.toJson(account))
+        handlingErrors {
+          case None          => AccountNotFound
+          case Some(account) => Ok(Json.toJson(account))
+        }
       }
     }
   }
@@ -74,26 +74,36 @@ class HelpToSaveController @Inject()
   override def putSavingsGoal(ninoString: String): Action[SavingsGoal] =
     authorisedWithIds.async(parse.json[SavingsGoal]) { implicit request: RequestWithIds[SavingsGoal] =>
       verifyingMatchingNino(config.shuttering, ninoString) { verifiedUserNino =>
-        accountService.setSavingsGoal(verifiedUserNino, request.body).map {
-          case Right(_)                             => NoContent
-          case Left(ErrorInfo.AccountNotFound)      => AccountNotFound
-          case Left(v@ErrorInfo.ValidationError(_)) => UnprocessableEntity(Json.toJson(v))
-          case Left(errorInfo)                      => InternalServerError(Json.toJson(errorInfo))
-        }
+        accountService.setSavingsGoal(verifiedUserNino, request.body).map(handlingErrors(_ => NoContent))
       }
     }
 
   override def deleteSavingsGoal(nino: String): Action[AnyContent] =
     authorisedWithIds.async { implicit request: RequestWithIds[AnyContent] =>
       verifyingMatchingNino(config.shuttering, nino) { verifiedNino =>
-        savingsGoalEventRepo.deleteGoal(verifiedNino).map(_ => NoContent)
+        accountService.deleteSavingsGoal(verifiedNino).map(handlingErrors(_ => NoContent))
       }
     }
 
   override def getSavingsGoalsEvents(nino: String): Action[AnyContent] =
     authorisedWithIds.async { implicit request: RequestWithIds[AnyContent] =>
       verifyingMatchingNino(config.shuttering, nino) { verifiedNino =>
-        savingsGoalEventRepo.getEvents(verifiedNino).map(events => Ok(Json.toJson(events)))
+        accountService.savingsGoalEvents(verifiedNino).map {
+          handlingErrors(events => Ok(Json.toJson(events)))
+        }
+      }
+    }
+
+  /**
+    * Standardise the mapping of ErrorInfo values to http responses
+    */
+  private def handlingErrors[T](rightHandler: T => Result)(a: Either[ErrorInfo, T]): Result =
+    a match {
+      case Right(t)        => rightHandler(t)
+      case Left(errorInfo) => errorInfo match {
+        case ErrorInfo.AccountNotFound      => AccountNotFound
+        case v@ErrorInfo.ValidationError(_) => UnprocessableEntity(Json.toJson(v))
+        case ErrorInfo.General              => InternalServerError(Json.toJson(ErrorInfo.General))
       }
     }
 }

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/GetAccountSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/GetAccountSpec.scala
@@ -22,12 +22,8 @@ import play.api.libs.json.Json
 import play.api.test.Helpers.{contentAsJson, status, _}
 import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
 import uk.gov.hmrc.mobilehelptosave.connectors.HelpToSaveGetTransactions
-import uk.gov.hmrc.mobilehelptosave.controllers.{
-  AlwaysAuthorisedWithIds,
-  HelpToSaveController
-}
+import uk.gov.hmrc.mobilehelptosave.controllers.{AlwaysAuthorisedWithIds, HelpToSaveController}
 import uk.gov.hmrc.mobilehelptosave.domain.{Account, ErrorInfo}
-import uk.gov.hmrc.mobilehelptosave.repository.SavingsGoalEventRepo
 import uk.gov.hmrc.mobilehelptosave.scalatest.SchemaMatchers
 import uk.gov.hmrc.mobilehelptosave.services.AccountService
 import uk.gov.hmrc.mobilehelptosave.support.LoggerStub
@@ -37,7 +33,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 //noinspection TypeAnnotation
 class GetAccountSpec
-    extends WordSpec
+  extends WordSpec
     with Matchers
     with SchemaMatchers
     with FutureAwaits
@@ -61,7 +57,7 @@ class GetAccountSpec
   "getAccount" when {
     "logged in user's NINO matches NINO in URL" should {
       "return 200 with the users account information obtained by passing NINO to AccountService" in new AuthorisedTestScenario
-      with HelpToSaveMocking {
+        with HelpToSaveMocking {
 
         accountReturns(Right(Some(mobileHelpToSaveAccount)))
 
@@ -74,7 +70,7 @@ class GetAccountSpec
 
     "there is a savings goal associated with the NINO" should {
       "return the savings goal in the account structure" in new AuthorisedTestScenario
-      with HelpToSaveMocking {
+        with HelpToSaveMocking {
         accountReturns(Right(Some(mobileHelpToSaveAccount)))
 
         val accountData = controller.getAccount(nino.value)(FakeRequest())
@@ -95,7 +91,7 @@ class GetAccountSpec
         (jsonBody \ "message")
           .as[String] shouldBe "No Help to Save account exists for the specified NINO"
 
-        (slf4jLoggerStub.warn(_: String)) verify * never ()
+        (slf4jLoggerStub.warn(_: String)) verify * never()
       }
     }
 
@@ -129,7 +125,8 @@ class GetAccountSpec
         val jsonBody = contentAsJson(resultF)
         (jsonBody \ "code").as[String] shouldBe "NINO_INVALID"
         (jsonBody \ "message")
-          .as[String] shouldBe """"invalidNino" does not match NINO validation regex"""
+          .as[String] shouldBe
+          """"invalidNino" does not match NINO validation regex"""
       }
     }
 
@@ -141,7 +138,8 @@ class GetAccountSpec
         val jsonBody = contentAsJson(resultF)
         (jsonBody \ "code").as[String] shouldBe "NINO_INVALID"
         (jsonBody \ "message")
-          .as[String] shouldBe """"AA 00 00 03 D" does not match NINO validation regex"""
+          .as[String] shouldBe
+          """"AA 00 00 03 D" does not match NINO validation regex"""
       }
     }
 
@@ -149,14 +147,12 @@ class GetAccountSpec
       """return 521 "shuttered": true""" in {
         val accountService = mock[AccountService]
         val helpToSaveGetTransactions = mock[HelpToSaveGetTransactions]
-        val savingsGoalEventRepo = mock[SavingsGoalEventRepo]
         val controller = new HelpToSaveController(
           logger,
           accountService,
           helpToSaveGetTransactions,
           new AlwaysAuthorisedWithIds(nino),
-          config.copy(shuttering = trueShuttering),
-          savingsGoalEventRepo
+          config.copy(shuttering = trueShuttering)
         )
 
         val resultF = controller.getAccount(nino.value)(FakeRequest())

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/GetTransactionsSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/GetTransactionsSpec.scala
@@ -24,7 +24,6 @@ import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
 import uk.gov.hmrc.mobilehelptosave.connectors.HelpToSaveGetTransactions
 import uk.gov.hmrc.mobilehelptosave.controllers.{AlwaysAuthorisedWithIds, HelpToSaveController}
 import uk.gov.hmrc.mobilehelptosave.domain.ErrorInfo
-import uk.gov.hmrc.mobilehelptosave.repository.SavingsGoalEventRepo
 import uk.gov.hmrc.mobilehelptosave.scalatest.SchemaMatchers
 import uk.gov.hmrc.mobilehelptosave.services.AccountService
 import uk.gov.hmrc.mobilehelptosave.support.LoggerStub
@@ -129,14 +128,14 @@ class GetTransactionsSpec
       """return 521 "shuttered": true""" in {
         val accountService = mock[AccountService]
         val helpToSaveGetTransactions = mock[HelpToSaveGetTransactions]
-        val savingsGoalEventRepo = mock[SavingsGoalEventRepo]
+
         val controller = new HelpToSaveController(
           logger,
           accountService,
           helpToSaveGetTransactions,
           new AlwaysAuthorisedWithIds(nino),
-          config.copy(shuttering = trueShuttering),
-          savingsGoalEventRepo)
+          config.copy(shuttering = trueShuttering)
+        )
 
         val resultF = controller.getTransactions(nino.value)(FakeRequest())
         status(resultF) shouldBe 521


### PR DESCRIPTION
This breaks the dependency from the controller to the repo.

Francis had already put in place some provision for lifting various errors to the value level using `Either` and `ErrorInfo`. This change expands on that, standardises a lot of responses and reduces boilerplate using helper functions.