### PR TITLE
Added test-only endpoint to remove savings goal event

### DIFF
--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/test/TestController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/test/TestController.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.mobilehelptosave.controllers.test
+
+import javax.inject.Inject
+import play.api.mvc.Results._
+import play.api.mvc.{Action, AnyContent}
+import uk.gov.hmrc.mobilehelptosave.repository.SavingsGoalEventRepo
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class TestController @Inject()(savingsGoalEventRepo: SavingsGoalEventRepo) {
+
+  def clearGoalEvents(): Action[AnyContent] = Action.async { implicit request =>
+    savingsGoalEventRepo.clearGoalEvents().map {
+      case true => Ok("Successfully cleared goal events")
+      case _ => Ok("Failed to clear goal events")
+    }
+  }
+
+}

--- a/app/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalEventRepo.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalEventRepo.scala
@@ -81,6 +81,7 @@ trait SavingsGoalEventRepo {
   def setGoal(nino: Nino, amount: Double): Future[Unit]
   def deleteGoal(nino: Nino): Future[Unit]
   def getEvents(nino: Nino): Future[List[SavingsGoalEvent]]
+  def clearGoalEvents(): Future[Boolean]
 }
 
 case class SavingsGoalEventsModel(nino: Nino, events: List[SavingsGoalEvent])
@@ -101,11 +102,16 @@ class MongoSavingsGoalEventRepo @Inject()(
   override def deleteGoal(nino: Nino): Future[Unit] =
     addEvent(SavingsGoalDeleteEvent(nino, LocalDateTime.now))
 
+  override def clearGoalEvents(): Future[Boolean] = {
+    drop
+  }
+
   private def addEvent(event: SavingsGoalEvent): Future[Unit] =
     atomicUpsert(
       BSONDocument(indexFieldName -> Json.toJson(event.nino)),
       BSONDocument("$push" -> obj("events" -> Json.toJson(event)))
     ).void
+
 
 
   override def getEvents(nino: Nino): Future[List[SavingsGoalEvent]] =

--- a/conf/test.routes
+++ b/conf/test.routes
@@ -1,0 +1,2 @@
+# Add all the application routes to the app.routes file
+GET        /clear-goal-events       uk.gov.hmrc.mobilehelptosave.controllers.test.TestController.clearGoalEvents

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -10,4 +10,5 @@
 # Failing to follow this rule may result in test routes deployed in production.
 
 # Add all the application routes to the prod.routes file
-->         /                          prod.Routes
+->        /                                     prod.Routes
+->        /mobile-help-to-save/test-only        test.Routes


### PR DESCRIPTION
This test-only endpoint is needed for testing so we can call it to ensure we have an empty collection after the tests run.