### PR TITLE
[DC] Rework events collection

### DIFF
--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
@@ -86,6 +86,4 @@ class HelpToSaveController @Inject()
         }
       }
     }
-
-
 }

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.mobilehelptosave.controllers
 
 import javax.inject.{Inject, Singleton}
 import play.api.LoggerLike
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, Writes}
 import play.api.mvc.{Action, AnyContent, Result}
 import uk.gov.hmrc.mobilehelptosave.config.HelpToSaveControllerConfig
 import uk.gov.hmrc.mobilehelptosave.connectors.HelpToSaveGetTransactions
@@ -45,65 +45,47 @@ class HelpToSaveController @Inject()
   authorisedWithIds: AuthorisedWithIds,
   config: HelpToSaveControllerConfig
 )(implicit ec: ExecutionContext) extends BaseController with ControllerChecks with HelpToSaveActions {
+  override def shuttering: Shuttering = config.shuttering
 
-  private final val AccountNotFound = NotFound(Json.toJson(ErrorBody("ACCOUNT_NOT_FOUND", "No Help to Save account exists for the specified NINO")))
+  private def orAccountNotFound[T: Writes](o: Option[T]): Result =
+    o.fold(AccountNotFound)(v => Ok(Json.toJson(v)))
 
   override def getTransactions(ninoString: String): Action[AnyContent] =
     authorisedWithIds.async { implicit request: RequestWithIds[AnyContent] =>
-      verifyingMatchingNino(config.shuttering, ninoString) { verifiedUserNino =>
-        helpToSaveGetTransactions.getTransactions(verifiedUserNino).map {
-          handlingErrors {
-            case Some(transactions) => Ok(Json.toJson(transactions.reverse))
-            case None               => AccountNotFound
-          }
-        }
+      verifyingMatchingNino(ninoString) { verifiedUserNino =>
+        helpToSaveGetTransactions.getTransactions(verifiedUserNino).map(handlingErrors(txs => Ok(Json.toJson(txs.reverse))))
       }
     }
 
   override def getAccount(ninoString: String): Action[AnyContent] = authorisedWithIds.async { implicit request: RequestWithIds[AnyContent] =>
-    verifyingMatchingNino(config.shuttering, ninoString) { nino =>
-      accountService.account(nino).map {
-        handlingErrors {
-          case None          => AccountNotFound
-          case Some(account) => Ok(Json.toJson(account))
-        }
-      }
+    verifyingMatchingNino(ninoString) { nino =>
+      //noinspection ConvertibleToMethodValue
+      accountService.account(nino).map(handlingErrors(orAccountNotFound(_)))
     }
   }
 
   override def putSavingsGoal(ninoString: String): Action[SavingsGoal] =
     authorisedWithIds.async(parse.json[SavingsGoal]) { implicit request: RequestWithIds[SavingsGoal] =>
-      verifyingMatchingNino(config.shuttering, ninoString) { verifiedUserNino =>
+      verifyingMatchingNino(ninoString) { verifiedUserNino =>
         accountService.setSavingsGoal(verifiedUserNino, request.body).map(handlingErrors(_ => NoContent))
       }
     }
 
   override def deleteSavingsGoal(nino: String): Action[AnyContent] =
     authorisedWithIds.async { implicit request: RequestWithIds[AnyContent] =>
-      verifyingMatchingNino(config.shuttering, nino) { verifiedNino =>
+      verifyingMatchingNino(nino) { verifiedNino =>
         accountService.deleteSavingsGoal(verifiedNino).map(handlingErrors(_ => NoContent))
       }
     }
 
   override def getSavingsGoalsEvents(nino: String): Action[AnyContent] =
     authorisedWithIds.async { implicit request: RequestWithIds[AnyContent] =>
-      verifyingMatchingNino(config.shuttering, nino) { verifiedNino =>
+      verifyingMatchingNino(nino) { verifiedNino =>
         accountService.savingsGoalEvents(verifiedNino).map {
           handlingErrors(events => Ok(Json.toJson(events)))
         }
       }
     }
 
-  /**
-    * Standardise the mapping of ErrorInfo values to http responses
-    */
-  private def handlingErrors[T](rightHandler: T => Result)(a: Either[ErrorInfo, T]): Result =
-    a match {
-      case Right(t)        => rightHandler(t)
-      case Left(errorInfo) => errorInfo match {
-        case ErrorInfo.AccountNotFound      => AccountNotFound
-        case v@ErrorInfo.ValidationError(_) => UnprocessableEntity(Json.toJson(v))
-        case ErrorInfo.General              => InternalServerError(Json.toJson(ErrorInfo.General))
-      }
-    }
+
 }

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/SandboxController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/SandboxController.scala
@@ -23,7 +23,7 @@ import play.api.LoggerLike
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.mobilehelptosave.config.HelpToSaveControllerConfig
-import uk.gov.hmrc.mobilehelptosave.domain.SavingsGoal
+import uk.gov.hmrc.mobilehelptosave.domain.{SavingsGoal, Shuttering}
 import uk.gov.hmrc.mobilehelptosave.repository.{SavingsGoalDeleteEvent, SavingsGoalEventsModel, SavingsGoalSetEvent}
 import uk.gov.hmrc.mobilehelptosave.sandbox.SandboxData
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
@@ -36,6 +36,7 @@ class SandboxController @Inject()(
   config: HelpToSaveControllerConfig,
   sandboxData: SandboxData
 ) extends BaseController with ControllerChecks with HelpToSaveActions {
+  override def shuttering: Shuttering = config.shuttering
 
   override def getTransactions(ninoString: String): Action[AnyContent] = Action.async { implicit request =>
     withShuttering(config.shuttering) {

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/SandboxController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/SandboxController.scala
@@ -24,7 +24,7 @@ import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.mobilehelptosave.config.HelpToSaveControllerConfig
 import uk.gov.hmrc.mobilehelptosave.domain.{SavingsGoal, Shuttering}
-import uk.gov.hmrc.mobilehelptosave.repository.{SavingsGoalDeleteEvent, SavingsGoalEventsModel, SavingsGoalSetEvent}
+import uk.gov.hmrc.mobilehelptosave.repository.{SavingsGoalDeleteEvent, SavingsGoalSetEvent}
 import uk.gov.hmrc.mobilehelptosave.sandbox.SandboxData
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
 
@@ -84,7 +84,7 @@ class SandboxController @Inject()(
             SavingsGoalSetEvent(nino, 35.0, LocalDateTime.of(2018, 12, 5, 10, 12, 33, 2298)),
             SavingsGoalSetEvent(nino, 35.0, LocalDateTime.of(2018, 12, 4, 10, 12, 33, 2298))
           )
-          Future.successful(Ok(Json.toJson(SavingsGoalEventsModel(nino, events))))
+          Future.successful(Ok(Json.toJson(events)))
         }
       }
     }

--- a/app/uk/gov/hmrc/mobilehelptosave/domain/ErrorInfo.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/domain/ErrorInfo.scala
@@ -23,8 +23,10 @@ sealed abstract class ErrorInfo(val code: String)
 
 object ErrorInfo {
   object General extends ErrorInfo("GENERAL")
-  object AccountNotFound extends ErrorInfo("ACCOUNT NOT FOUND")
-  case class ValidationError(message: String) extends ErrorInfo("VALIDATION ERROR")
+  object AccountNotFound extends ErrorInfo("ACCOUNT_NOT_FOUND") {
+    val message: String = "No Help to Save account exists for the specified NINO"
+  }
+  case class ValidationError(message: String) extends ErrorInfo("VALIDATION_ERROR")
 
   implicit val writes: OWrites[ErrorInfo] = new OWrites[ErrorInfo] {
     override def writes(o: ErrorInfo): JsObject = o match {

--- a/app/uk/gov/hmrc/mobilehelptosave/repository/IndexedMongoRepo.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/repository/IndexedMongoRepo.scala
@@ -41,12 +41,13 @@ import scala.concurrent.{ExecutionContext, Future}
 class IndexedMongoRepo[I, V: Manifest](
   collectionName: String,
   val indexFieldName: String,
+  unique:Boolean,
   mongo: ReactiveMongoComponent
 )(implicit ec: ExecutionContext, iFormat: Format[I], tFormat: Format[V])
   extends ReactiveRepository[V, BSONObjectID](collectionName, mongo.mongoConnector.db, tFormat) with AtomicUpdate[V] {
 
   override def indexes: Seq[Index] = Seq(
-    Index(Seq(indexFieldName -> IndexType.Text), name = Some(s"${indexFieldName}Idx"), unique = true, sparse = true)
+    Index(Seq(indexFieldName -> IndexType.Text), name = Some(s"${indexFieldName}Idx"), unique = unique, sparse = true)
   )
 
   /**

--- a/app/uk/gov/hmrc/mobilehelptosave/services/AccountService.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/services/AccountService.scala
@@ -66,7 +66,7 @@ class HelpToSaveAccountService @Inject()(
     }
 
   override def getSavingsGoal(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Result[Option[SavingsGoal]]] =
-    expectingAccount(nino) { _ =>
+    withHelpToSaveAccount(nino) { _ =>
       trappingRepoExceptions("error reading goal from events repo", savingsGoalEventRepo.getGoal(nino))
     }
 

--- a/app/uk/gov/hmrc/mobilehelptosave/services/AccountService.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/services/AccountService.scala
@@ -16,8 +16,6 @@
 
 package uk.gov.hmrc.mobilehelptosave.services
 
-import java.time.LocalDateTime
-
 import cats.data.EitherT
 import cats.instances.future._
 import cats.syntax.apply._
@@ -43,6 +41,7 @@ trait AccountService {
   def account(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Result[Option[Account]]]
 
   def setSavingsGoal(nino: Nino, savingsGoal: SavingsGoal)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Result[Unit]]
+  def getSavingsGoal(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Result[Option[SavingsGoal]]]
   def deleteSavingsGoal(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Result[Unit]]
 
   def savingsGoalEvents(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Result[List[SavingsGoalEvent]]]
@@ -65,6 +64,11 @@ class HelpToSaveAccountService @Inject()(
         Future.successful(ErrorInfo.ValidationError(s"goal amount should be in range 1 to $maxGoal").asLeft)
       else
         trappingRepoExceptions("error writing savings goal to repo", savingsGoalEventRepo.setGoal(nino, savingsGoal.goalAmount))
+    }
+
+  override def getSavingsGoal(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Result[Option[SavingsGoal]]] =
+    expectingAccount(nino) { _ =>
+      trappingRepoExceptions("error reading goal from events repo", savingsGoalEventRepo.getGoal(nino))
     }
 
   override def deleteSavingsGoal(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Result[Unit]] =
@@ -111,7 +115,7 @@ class HelpToSaveAccountService @Inject()(
       fetchNSAndIAccount(nino)
     ).mapN {
       case (Right(goal), Right(Some(account))) =>
-        val savingsGoal = goal.map(t => SavingsGoal(t.amount))
+        val savingsGoal = goal.map(t => SavingsGoal(t.goalAmount))
         Some(account.copy(savingsGoal = savingsGoal, savingsGoalsEnabled = config.savingsGoalsEnabled)).asRight
 
       case (_, Left(errorInfo)) => errorInfo.asLeft
@@ -131,19 +135,11 @@ class HelpToSaveAccountService @Inject()(
     }.value
 
 
-  private val localDateTimeOrdering: Ordering[LocalDateTime] = new Ordering[LocalDateTime] {
-    override def compare(x: LocalDateTime, y: LocalDateTime): Int = x.compareTo(y)
-  }
-
-  private def fetchSavingsGoal(nino: Nino)(implicit ec: ExecutionContext): Future[Result[Option[SavingsGoalRepoModel]]] = {
-    savingsGoalEventRepo.getEvents(nino).map(_.sortBy(_.date)(localDateTimeOrdering.reverse)).map {
-      case List()                                    => None.asRight[ErrorInfo]
-      case SavingsGoalDeleteEvent(_, _) :: _         => None.asRight[ErrorInfo]
-      case SavingsGoalSetEvent(_, amount, date) :: _ => Some(SavingsGoalRepoModel(nino, amount, date)).asRight[ErrorInfo]
-    }.recover {
+  private def fetchSavingsGoal(nino: Nino)(implicit ec: ExecutionContext): Future[Result[Option[SavingsGoal]]] = {
+    savingsGoalEventRepo.getGoal(nino).map(_.asRight[ErrorInfo]).recover {
       case t =>
         logger.warn("call to repo to retrieve savings goal failed", t)
-        ErrorInfo.General.asLeft[Option[SavingsGoalRepoModel]]
+        ErrorInfo.General.asLeft[Option[SavingsGoal]]
     }
   }
 

--- a/app/uk/gov/hmrc/mobilehelptosave/services/package.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/services/package.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.mobilehelptosave
+
+import java.time.LocalDateTime
+
+package object services {
+  val localDateTimeOrdering: Ordering[LocalDateTime] = new Ordering[LocalDateTime] {
+    override def compare(x: LocalDateTime, y: LocalDateTime): Int = x.compareTo(y)
+  }
+}

--- a/it/uk/gov/hmrc/mobilehelptosave/SandboxISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/SandboxISpec.scala
@@ -25,7 +25,7 @@ import play.api.libs.ws.WSResponse
 import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
 import uk.gov.hmrc.domain.Generator
 import uk.gov.hmrc.mobilehelptosave.domain.{Account, SavingsGoal, Transactions}
-import uk.gov.hmrc.mobilehelptosave.repository.SavingsGoalEventsModel
+import uk.gov.hmrc.mobilehelptosave.repository.SavingsGoalEvent
 import uk.gov.hmrc.mobilehelptosave.scalatest.SchemaMatchers
 import uk.gov.hmrc.mobilehelptosave.support.{OneServerPerSuiteWsClient, WireMockSupport}
 
@@ -76,7 +76,7 @@ class SandboxISpec extends WordSpec with Matchers
     "Return OK response containing events JSON" in {
       val response: WSResponse = await(wsUrl(s"/savings-account/$nino/goals/events").withHeaders(sandboxRoutingHeader).get())
       response.status shouldBe Status.OK
-      response.json.validate[SavingsGoalEventsModel] shouldBe 'success
+      response.json.validate[List[SavingsGoalEvent]] shouldBe 'success
     }
   }
 }

--- a/test/uk/gov/hmrc/mobilehelptosave/connectors/HelpToSaveConnectorSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/connectors/HelpToSaveConnectorSpec.scala
@@ -190,16 +190,17 @@ class HelpToSaveConnectorSpec
 
       val connector = new HelpToSaveConnectorImpl(logger, config, okResponse)
 
-      await(connector.getTransactions(nino)) shouldBe Right(Some(transactionsSortedInHelpToSaveOrder))
+      await(connector.getTransactions(nino)) shouldBe Right(transactionsSortedInHelpToSaveOrder)
     }
 
-    "return Right(None) when the help-to-save service returns a 404 response" in {
+    "return Left(AccountNotFound) when the help-to-save service returns a 404 response" in {
 
       val notFoundResponse = httpGet(isTransactionsUrlForNino _, HttpResponse(404))
 
       val connector = new HelpToSaveConnectorImpl(logger, config, notFoundResponse)
 
-      await(connector.getTransactions(nino)) shouldBe Right(None)
+      val result = await(connector.getTransactions(nino))
+      result shouldBe Left(ErrorInfo.AccountNotFound)
     }
   }
 

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/GetTransactionsSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/GetTransactionsSpec.scala
@@ -59,7 +59,7 @@ class GetTransactionsSpec
     "logged in user's NINO matches NINO in URL" should {
       "return 200 with transactions obtained by passing NINO to the HelpToSaveConnector" in new AuthorisedTestScenario with HelpToSaveMocking {
 
-        helpToSaveGetTransactionsReturns(Future successful Right(Some(transactionsSortedInHelpToSaveOrder)))
+        helpToSaveGetTransactionsReturns(Future successful Right(transactionsSortedInHelpToSaveOrder))
 
         val resultF = controller.getTransactions(nino.value)(FakeRequest())
         status(resultF) shouldBe 200
@@ -71,7 +71,7 @@ class GetTransactionsSpec
     "no account is not found by HelpToSaveConnector for the NINO" should {
       "return 404" in new AuthorisedTestScenario with HelpToSaveMocking {
 
-        helpToSaveGetTransactionsReturns(Future successful Right(None))
+        helpToSaveGetTransactionsReturns(Future successful Left(ErrorInfo.AccountNotFound))
 
         val resultF = controller.getTransactions(nino.value)(FakeRequest())
         status(resultF) shouldBe 404

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/TestSupport.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/TestSupport.scala
@@ -78,7 +78,7 @@ trait TestSupport {
         .returning(Future.successful(stubbedResponse))
     }
 
-    def helpToSaveGetTransactionsReturns(stubbedResponse: Future[Either[ErrorInfo, Option[Transactions]]]) = {
+    def helpToSaveGetTransactionsReturns(stubbedResponse: Future[Either[ErrorInfo, Transactions]]) = {
       (helpToSaveGetTransactions.getTransactions(_: Nino)(_: HeaderCarrier, _: ExecutionContext))
         .expects(nino, *, *)
         .returning(stubbedResponse)

--- a/test/uk/gov/hmrc/mobilehelptosave/services/SetSavingsGoalSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/services/SetSavingsGoalSpec.scala
@@ -156,6 +156,7 @@ class SetSavingsGoalSpec
     }
 
     override def clearGoalEvents(): Future[Boolean] = Future.successful(true)
+    override def getGoal(nino: Nino): Future[Option[SavingsGoal]] = ???
   }
 
   object ShouldNotBeCalledGetAccount extends HelpToSaveGetAccount {


### PR DESCRIPTION
I have re-worked the savings goal event collection. Now, rather than storing an object for the nino with a list of events inside it, the collection just stores events. Events already contain the nino, so it's no problem to select events for a given user, and it makes it easy to have mongo sort and return only the latest event when we just want to determine what the current savings goal is.

This PR also includes changes to the transactions api so that rather than signalling no-account by returning an `Right[Option[List[Transaction]]]`, the call will return `Right[List[Transaction]]` if the account exists and `Left(AccountNotFound)` if it doesn't, to be consistent with other calls (apart from the `account` call, which I've yet to convert) and then the standard error handling in the controller can deal with the result.