### PR TITLE
Formatting and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 !.gitignore
 !.travis.yml
+!.scalafmt.conf
 
 .cache
 /.classpath

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,45 @@
+style = defaultWithAlign
+maxColumn = 150
+lineEndings = unix
+importSelectors = singleLine
+
+project {
+  git = true
+}
+
+align = most
+
+align {
+  tokens = [ {code = "=>", owner = "Case|Type.Arg.ByName"}, "=", "<-", "->", "%", "%%", "should", "shouldBe", "must", ":" ]
+  arrowEnumeratorGenerator = true
+  openParenCallSite = false
+  openParenDefnSite = false
+}
+
+binPack {
+  parentConstructors = false
+}
+
+continuationIndent {
+  callSite = 2
+  defnSite = 2
+}
+
+newlines {
+  penalizeSingleSelectMultiArgList = false
+  sometimesBeforeColonInMethodReturnType = true
+}
+
+rewrite {
+  rules = [RedundantBraces, RedundantParens, AsciiSortImports]
+  redundantBraces {
+    maxLines = 100
+    includeUnitMethods = true
+    stringInterpolation = true
+  }
+}
+
+spaces {
+  inImportCurlyBraces = false
+  beforeContextBoundColon = false
+}

--- a/app/uk/gov/hmrc/mobilehelptosave/api/DocumentationController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/api/DocumentationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ object ApiAccess {
 
 class DocumentationController(
   errorHandler: HttpErrorHandler,
-  config: DocumentationControllerConfig
+  config:       DocumentationControllerConfig
 ) extends uk.gov.hmrc.api.controllers.DocumentationController(errorHandler) {
 
   private lazy val apiAccess = ApiAccess(config.apiAccessType, config.apiWhiteListApplicationIds)

--- a/app/uk/gov/hmrc/mobilehelptosave/api/ServiceLocatorRegistrationTask.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/api/ServiceLocatorRegistrationTask.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,9 +27,9 @@ import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 
 class ServiceLocatorRegistrationTask(
-  actorSystem: ActorSystem,
-  connector: ServiceLocatorConnector,
-  config: ServiceLocatorRegistrationTaskConfig
+  actorSystem:               ActorSystem,
+  connector:                 ServiceLocatorConnector,
+  config:                    ServiceLocatorRegistrationTaskConfig
 )(implicit executionContext: ExecutionContext) {
   if (config.serviceLocatorEnabled) {
     actorSystem.scheduler.scheduleOnce(delay = FiniteDuration(10, SECONDS)) {

--- a/app/uk/gov/hmrc/mobilehelptosave/config/Base64.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/config/Base64.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/mobilehelptosave/config/MobileHelpToSaveConfig.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/config/MobileHelpToSaveConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,9 @@ import uk.gov.hmrc.play.config.ServicesConfig
 import scala.collection.JavaConverters._
 
 case class MobileHelpToSaveConfig(
-  environment: Environment,
+  environment:   Environment,
   configuration: Configuration
-)
-  extends ServicesConfig
+) extends ServicesConfig
     with AccountServiceConfig
     with DocumentationControllerConfig
     with HelpToSaveConnectorConfig
@@ -38,7 +37,7 @@ case class MobileHelpToSaveConfig(
     with ServiceLocatorRegistrationTaskConfig
     with StartupControllerConfig {
 
-  override protected lazy val mode: Mode = environment.mode
+  override protected lazy val mode:            Mode          = environment.mode
   override protected def runModeConfiguration: Configuration = configuration
 
   // These are eager vals so that missing or invalid configuration will be detected on startup
@@ -48,19 +47,19 @@ case class MobileHelpToSaveConfig(
 
   override val shuttering: Shuttering = Shuttering(
     shuttered = configBoolean("helpToSave.shuttering.shuttered"),
-    title = configBase64String("helpToSave.shuttering.title"),
-    message = configBase64String("helpToSave.shuttering.message")
+    title     = configBase64String("helpToSave.shuttering.title"),
+    message   = configBase64String("helpToSave.shuttering.message")
   )
 
   override def savingsGoalsEnabled: Boolean = configBoolean("helpToSave.savingsGoalsEnabled")
 
-  override val supportFormEnabled        : Boolean = configBoolean("helpToSave.supportFormEnabled")
-  override val inAppPaymentsEnabled      : Boolean = configBoolean("helpToSave.inAppPaymentsEnabled")
-  override val helpToSaveInfoUrl         : String  = configString("helpToSave.infoUrl")
+  override val supportFormEnabled:         Boolean = configBoolean("helpToSave.supportFormEnabled")
+  override val inAppPaymentsEnabled:       Boolean = configBoolean("helpToSave.inAppPaymentsEnabled")
+  override val helpToSaveInfoUrl:          String  = configString("helpToSave.infoUrl")
   override val helpToSaveAccessAccountUrl: String  = configString("helpToSave.accessAccountUrl")
 
-  private  val accessConfig                            = configuration.underlying.getConfig("api.access")
-  override val apiAccessType             : String      = accessConfig.getString("type")
+  private val accessConfig = configuration.underlying.getConfig("api.access")
+  override val apiAccessType:              String      = accessConfig.getString("type")
   override val apiWhiteListApplicationIds: Seq[String] = accessConfig.getStringList("white-list.applicationIds").asScala
 
   protected def configBaseUrl(serviceName: String): URL = new URL(baseUrl(serviceName))
@@ -78,7 +77,7 @@ case class MobileHelpToSaveConfig(
 
 trait AccountServiceConfig {
   def inAppPaymentsEnabled: Boolean
-  def savingsGoalsEnabled: Boolean
+  def savingsGoalsEnabled:  Boolean
 }
 
 trait SandboxDataConfig {
@@ -86,7 +85,7 @@ trait SandboxDataConfig {
 }
 
 trait DocumentationControllerConfig {
-  def apiAccessType: String
+  def apiAccessType:              String
   def apiWhiteListApplicationIds: Seq[String]
 }
 
@@ -99,9 +98,9 @@ trait ServiceLocatorRegistrationTaskConfig {
 }
 
 trait StartupControllerConfig {
-  def shuttering: Shuttering
-  def supportFormEnabled: Boolean
-  def helpToSaveInfoUrl: String
+  def shuttering:                 Shuttering
+  def supportFormEnabled:         Boolean
+  def helpToSaveInfoUrl:          String
   def helpToSaveAccessAccountUrl: String
 }
 

--- a/app/uk/gov/hmrc/mobilehelptosave/config/ScalaUriConfig.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/config/ScalaUriConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/mobilehelptosave/config/SystemId.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/config/SystemId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/mobilehelptosave/connectors/HelpToSaveConnector.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/connectors/HelpToSaveConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,21 +47,20 @@ trait HelpToSaveGetTransactions[F[_]] {
 class HelpToSaveConnectorImpl(
   logger: LoggerLike,
   config: HelpToSaveConnectorConfig,
-  http: CoreGet
+  http:   CoreGet
 )(
   implicit ec: ExecutionContext
-)
-  extends HelpToSaveGetTransactions[Future]
+) extends HelpToSaveGetTransactions[Future]
     with HelpToSaveGetAccount[Future]
     with HelpToSaveEnrolmentStatus[Future] {
 
-  override def enrolmentStatus()(implicit hc: HeaderCarrier): Future[Either[ErrorInfo, Boolean]] = {
+  override def enrolmentStatus()(implicit hc: HeaderCarrier): Future[Either[ErrorInfo, Boolean]] =
     http.GET[JsValue](enrolmentStatusUrl.toString) map { json: JsValue =>
       Right((json \ "enrolled").as[Boolean])
     } recover handleEnrolmentStatusHttpErrors
-  }
 
-  override def getAccount(nino: Nino)(implicit hc: HeaderCarrier): Future[Either[ErrorInfo, Option[HelpToSaveAccount]]] = {
+  override def getAccount(nino: Nino)(
+    implicit hc:                HeaderCarrier): Future[Either[ErrorInfo, Option[HelpToSaveAccount]]] = {
     val string = accountUrl(nino).toString
     http.GET[HelpToSaveAccount](string) map (account => Right(Some(account))) recover (mapNotFoundToNone orElse handleAccountHttpErrors)
   }
@@ -80,7 +79,8 @@ class HelpToSaveConnectorImpl(
     case _: NotFoundException =>
       Left(ErrorInfo.AccountNotFound)
 
-    case e@(_: HttpException | _: Upstream4xxResponse | _: Upstream5xxResponse | _: JsValidationException | _: JsonParseException) =>
+    case e @ (_: HttpException | _: Upstream4xxResponse | _: Upstream5xxResponse | _: JsValidationException |
+        _: JsonParseException) =>
       logger.warn(s"Couldn't get $dataDescription from help-to-save service", e)
       Left(ErrorInfo.General)
   }
@@ -91,19 +91,22 @@ class HelpToSaveConnectorImpl(
 
   private lazy val enrolmentStatusUrl: URL = new URL(config.helpToSaveBaseUrl, "/help-to-save/enrolment-status")
 
-  private def accountUrl(nino: Nino): URL = new URL(
-    config.helpToSaveBaseUrl, s"/help-to-save/${encodePathSegment(nino.value)}/account" ? ("systemId" -> SystemId))
+  private def accountUrl(nino: Nino): URL =
+    new URL(
+      config.helpToSaveBaseUrl,
+      s"/help-to-save/${encodePathSegment(nino.value)}/account" ? ("systemId" -> SystemId))
 
-  private def transactionsUrl(nino: Nino): URL = new URL(
-    config.helpToSaveBaseUrl, s"/help-to-save/${encodePathSegment(nino.value)}/account/transactions" ? ("systemId" -> SystemId))
+  private def transactionsUrl(nino: Nino): URL =
+    new URL(
+      config.helpToSaveBaseUrl,
+      s"/help-to-save/${encodePathSegment(nino.value)}/account/transactions" ? ("systemId" -> SystemId))
 }
-
 
 /** Bonus term in help-to-save microservice's domain */
 case class HelpToSaveBonusTerm(
-  bonusEstimate: BigDecimal,
-  bonusPaid: BigDecimal,
-  endDate: LocalDate,
+  bonusEstimate:          BigDecimal,
+  bonusPaid:              BigDecimal,
+  endDate:                LocalDate,
   bonusPaidOnOrAfterDate: LocalDate
 )
 
@@ -113,31 +116,24 @@ object HelpToSaveBonusTerm {
 
 /** Account in help-to-save microservice's domain */
 case class HelpToSaveAccount(
-  accountNumber: String,
-  openedYearMonth: YearMonth,
-
-  isClosed: Boolean,
-
-  blocked: Blocking,
-
-  balance: BigDecimal,
-
-  paidInThisMonth: BigDecimal,
-  canPayInThisMonth: BigDecimal,
+  accountNumber:          String,
+  openedYearMonth:        YearMonth,
+  isClosed:               Boolean,
+  blocked:                Blocking,
+  balance:                BigDecimal,
+  paidInThisMonth:        BigDecimal,
+  canPayInThisMonth:      BigDecimal,
   maximumPaidInThisMonth: BigDecimal,
-  thisMonthEndDate: LocalDate,
-
-  accountHolderForename: String,
-  accountHolderSurname: String,
-  accountHolderEmail: Option[String],
-
-  bonusTerms: Seq[HelpToSaveBonusTerm],
-
-  closureDate: Option[LocalDate],
-  closingBalance: Option[BigDecimal]
+  thisMonthEndDate:       LocalDate,
+  accountHolderForename:  String,
+  accountHolderSurname:   String,
+  accountHolderEmail:     Option[String],
+  bonusTerms:             Seq[HelpToSaveBonusTerm],
+  closureDate:            Option[LocalDate],
+  closingBalance:         Option[BigDecimal]
 )
 
 object HelpToSaveAccount {
   implicit val jodaFormat: Format[YearMonth]        = uk.gov.hmrc.mobilehelptosave.json.Formats.JodaYearMonthFormat
-  implicit val reads     : Reads[HelpToSaveAccount] = Json.reads[HelpToSaveAccount]
+  implicit val reads:      Reads[HelpToSaveAccount] = Json.reads[HelpToSaveAccount]
 }

--- a/app/uk/gov/hmrc/mobilehelptosave/connectors/HelpToSaveConnector.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/connectors/HelpToSaveConnector.scala
@@ -59,8 +59,7 @@ class HelpToSaveConnectorImpl(
       Right((json \ "enrolled").as[Boolean])
     } recover handleEnrolmentStatusHttpErrors
 
-  override def getAccount(nino: Nino)(
-    implicit hc:                HeaderCarrier): Future[Either[ErrorInfo, Option[HelpToSaveAccount]]] = {
+  override def getAccount(nino: Nino)(implicit hc: HeaderCarrier): Future[Either[ErrorInfo, Option[HelpToSaveAccount]]] = {
     val string = accountUrl(nino).toString
     http.GET[HelpToSaveAccount](string) map (account => Right(Some(account))) recover (mapNotFoundToNone orElse handleAccountHttpErrors)
   }
@@ -79,8 +78,7 @@ class HelpToSaveConnectorImpl(
     case _: NotFoundException =>
       Left(ErrorInfo.AccountNotFound)
 
-    case e @ (_: HttpException | _: Upstream4xxResponse | _: Upstream5xxResponse | _: JsValidationException |
-        _: JsonParseException) =>
+    case e @ (_: HttpException | _: Upstream4xxResponse | _: Upstream5xxResponse | _: JsValidationException | _: JsonParseException) =>
       logger.warn(s"Couldn't get $dataDescription from help-to-save service", e)
       Left(ErrorInfo.General)
   }
@@ -92,14 +90,10 @@ class HelpToSaveConnectorImpl(
   private lazy val enrolmentStatusUrl: URL = new URL(config.helpToSaveBaseUrl, "/help-to-save/enrolment-status")
 
   private def accountUrl(nino: Nino): URL =
-    new URL(
-      config.helpToSaveBaseUrl,
-      s"/help-to-save/${encodePathSegment(nino.value)}/account" ? ("systemId" -> SystemId))
+    new URL(config.helpToSaveBaseUrl, s"/help-to-save/${encodePathSegment(nino.value)}/account" ? ("systemId" -> SystemId))
 
   private def transactionsUrl(nino: Nino): URL =
-    new URL(
-      config.helpToSaveBaseUrl,
-      s"/help-to-save/${encodePathSegment(nino.value)}/account/transactions" ? ("systemId" -> SystemId))
+    new URL(config.helpToSaveBaseUrl, s"/help-to-save/${encodePathSegment(nino.value)}/account/transactions" ? ("systemId" -> SystemId))
 }
 
 /** Bonus term in help-to-save microservice's domain */

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/AuthorisedWithIds.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/AuthorisedWithIds.scala
@@ -55,8 +55,7 @@ class AuthorisedWithIdsImpl(
       .recover {
         case e: NoActiveSession => Left(Unauthorized(s"Authorisation failure [${e.reason}]"))
         case e: InsufficientConfidenceLevel =>
-          logger.warn(
-            "Forbidding access due to insufficient confidence level. User will see an error screen. To fix this see NGC-3381.")
+          logger.warn("Forbidding access due to insufficient confidence level. User will see an error screen. To fix this see NGC-3381.")
           Left(Forbidden(s"Authorisation failure [${e.reason}]"))
         case e: AuthorisationException => Left(Forbidden(s"Authorisation failure [${e.reason}]"))
       }

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/AuthorisedWithIds.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/AuthorisedWithIds.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,27 +31,34 @@ class RequestWithIds[+A](val nino: Nino, request: Request[A]) extends WrappedReq
 trait AuthorisedWithIds extends ActionBuilder[RequestWithIds] with ActionRefiner[Request, RequestWithIds]
 
 class AuthorisedWithIdsImpl(
-  logger: LoggerLike,
+  logger:        LoggerLike,
   authConnector: AuthConnector
-)(implicit ec: ExecutionContext) extends AuthorisedWithIds with Results {
+)(
+  implicit ec: ExecutionContext
+) extends AuthorisedWithIds
+    with Results {
   override protected def refine[A](request: Request[A]): Future[Either[Result, RequestWithIds[A]]] = {
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers)
 
     val predicates = ConfidenceLevel.L200
     val retrievals = Retrievals.nino
 
-    authConnector.authorise(predicates, retrievals).map {
-      case Some(nino) =>
-        Right(new RequestWithIds(Nino(nino), request))
-      case None       =>
-        logger.warn("NINO not found")
-        Left(Forbidden("NINO not found"))
-    }.recover {
-      case e: NoActiveSession             => Left(Unauthorized(s"Authorisation failure [${e.reason}]"))
-      case e: InsufficientConfidenceLevel =>
-        logger.warn("Forbidding access due to insufficient confidence level. User will see an error screen. To fix this see NGC-3381.")
-        Left(Forbidden(s"Authorisation failure [${e.reason}]"))
-      case e: AuthorisationException      => Left(Forbidden(s"Authorisation failure [${e.reason}]"))
-    }
+    authConnector
+      .authorise(predicates, retrievals)
+      .map {
+        case Some(nino) =>
+          Right(new RequestWithIds(Nino(nino), request))
+        case None =>
+          logger.warn("NINO not found")
+          Left(Forbidden("NINO not found"))
+      }
+      .recover {
+        case e: NoActiveSession => Left(Unauthorized(s"Authorisation failure [${e.reason}]"))
+        case e: InsufficientConfidenceLevel =>
+          logger.warn(
+            "Forbidding access due to insufficient confidence level. User will see an error screen. To fix this see NGC-3381.")
+          Left(Forbidden(s"Authorisation failure [${e.reason}]"))
+        case e: AuthorisationException => Left(Forbidden(s"Authorisation failure [${e.reason}]"))
+      }
   }
 }

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/ControllerChecks.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/ControllerChecks.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,28 +35,28 @@ trait ControllerChecks extends Results {
 
   def shuttering: Shuttering
 
-  def withShuttering(shuttering: Shuttering)(fn: => Future[Result]): Future[Result] = {
+  def withShuttering(shuttering: Shuttering)(fn: => Future[Result]): Future[Result] =
     if (shuttering.shuttered) successful(WebServerIsDown(Json.toJson(shuttering))) else fn
-  }
 
-  def withValidNino(nino: String)(fn: Nino => Future[Result]): Future[Result] = {
+  def withValidNino(nino: String)(fn: Nino => Future[Result]): Future[Result] =
     HmrcNinoDefinition.regex.findFirstIn(nino) map (n => Right(Try(Nino(n)))) getOrElse {
       Left(s""""$nino" does not match NINO validation regex""")
     } match {
       case Right(Success(parsedNino)) => fn(parsedNino)
-      case Right(Failure(exception))  => successful(BadRequest(Json.toJson(ErrorBody("NINO_INVALID", exception.getMessage))))
-      case Left(validationError)      => successful(BadRequest(Json.toJson(ErrorBody("NINO_INVALID", validationError))))
+      case Right(Failure(exception)) =>
+        successful(BadRequest(Json.toJson(ErrorBody("NINO_INVALID", exception.getMessage))))
+      case Left(validationError) => successful(BadRequest(Json.toJson(ErrorBody("NINO_INVALID", validationError))))
     }
-  }
 
-  def withMatchingNinos(nino: Nino)(fn: Nino => Future[Result])(implicit request: RequestWithIds[_]): Future[Result] = {
-    if (nino == request.nino) fn(nino) else {
+  def withMatchingNinos(nino: Nino)(fn: Nino => Future[Result])(implicit request: RequestWithIds[_]): Future[Result] =
+    if (nino == request.nino) fn(nino)
+    else {
       logger.warn(s"Attempt by ${request.nino} to access ${nino.value}'s data")
       successful(Forbidden)
     }
-  }
 
-  def verifyingMatchingNino(ninoString: String)(fn: Nino => Future[Result])(implicit request: RequestWithIds[_]): Future[Result] = {
+  def verifyingMatchingNino(ninoString: String)(fn: Nino => Future[Result])(
+    implicit request:                   RequestWithIds[_]): Future[Result] =
     withShuttering(shuttering) {
       withValidNino(ninoString) { validNino =>
         withMatchingNinos(validNino) { verifiedUserNino =>
@@ -64,13 +64,13 @@ trait ControllerChecks extends Results {
         }
       }
     }
-  }
 
-  protected final val AccountNotFound = NotFound(Json.toJson(ErrorBody("ACCOUNT_NOT_FOUND", "No Help to Save account exists for the specified NINO")))
+  protected final val AccountNotFound = NotFound(
+    Json.toJson(ErrorBody("ACCOUNT_NOT_FOUND", "No Help to Save account exists for the specified NINO")))
   private def errorHandler(errorInfo: ErrorInfo): Result = errorInfo match {
-    case ErrorInfo.AccountNotFound      => AccountNotFound
-    case v@ErrorInfo.ValidationError(_) => UnprocessableEntity(Json.toJson(v))
-    case ErrorInfo.General              => InternalServerError(Json.toJson(ErrorInfo.General))
+    case ErrorInfo.AccountNotFound        => AccountNotFound
+    case v @ ErrorInfo.ValidationError(_) => UnprocessableEntity(Json.toJson(v))
+    case ErrorInfo.General                => InternalServerError(Json.toJson(ErrorInfo.General))
   }
 
   /**

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/ControllerChecks.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/ControllerChecks.scala
@@ -55,8 +55,7 @@ trait ControllerChecks extends Results {
       successful(Forbidden)
     }
 
-  def verifyingMatchingNino(ninoString: String)(fn: Nino => Future[Result])(
-    implicit request:                   RequestWithIds[_]): Future[Result] =
+  def verifyingMatchingNino(ninoString: String)(fn: Nino => Future[Result])(implicit request: RequestWithIds[_]): Future[Result] =
     withShuttering(shuttering) {
       withValidNino(ninoString) { validNino =>
         withMatchingNinos(validNino) { verifiedUserNino =>
@@ -65,8 +64,7 @@ trait ControllerChecks extends Results {
       }
     }
 
-  protected final val AccountNotFound = NotFound(
-    Json.toJson(ErrorBody("ACCOUNT_NOT_FOUND", "No Help to Save account exists for the specified NINO")))
+  protected final val AccountNotFound = NotFound(Json.toJson(ErrorBody("ACCOUNT_NOT_FOUND", "No Help to Save account exists for the specified NINO")))
   private def errorHandler(errorInfo: ErrorInfo): Result = errorInfo match {
     case ErrorInfo.AccountNotFound        => AccountNotFound
     case v @ ErrorInfo.ValidationError(_) => UnprocessableEntity(Json.toJson(v))

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
@@ -60,12 +60,11 @@ class HelpToSaveController(
       }
     }
 
-  override def getAccount(ninoString: String): Action[AnyContent] = authorisedWithIds.async {
-    implicit request: RequestWithIds[AnyContent] =>
-      verifyingMatchingNino(ninoString) { nino =>
-        //noinspection ConvertibleToMethodValue
-        accountService.account(nino).map(handlingErrors(orAccountNotFound(_)))
-      }
+  override def getAccount(ninoString: String): Action[AnyContent] = authorisedWithIds.async { implicit request: RequestWithIds[AnyContent] =>
+    verifyingMatchingNino(ninoString) { nino =>
+      //noinspection ConvertibleToMethodValue
+      accountService.account(nino).map(handlingErrors(orAccountNotFound(_)))
+    }
   }
 
   override def putSavingsGoal(ninoString: String): Action[SavingsGoal] =

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/HelpToSaveController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,21 +28,24 @@ import uk.gov.hmrc.play.bootstrap.controller.BaseController
 import scala.concurrent.{ExecutionContext, Future}
 
 trait HelpToSaveActions {
-  def getTransactions(ninoString: String): Action[AnyContent]
-  def getAccount(ninoString: String): Action[AnyContent]
-  def putSavingsGoal(ninoString: String): Action[SavingsGoal]
+  def getTransactions(ninoString:   String): Action[AnyContent]
+  def getAccount(ninoString:        String): Action[AnyContent]
+  def putSavingsGoal(ninoString:    String): Action[SavingsGoal]
   def deleteSavingsGoal(ninoString: String): Action[AnyContent]
-  def getSavingsGoalsEvents(nino: String): Action[AnyContent]
+  def getSavingsGoalsEvents(nino:   String): Action[AnyContent]
 }
 
-class HelpToSaveController
-(
-  val logger: LoggerLike,
-  accountService: AccountService[Future],
+class HelpToSaveController(
+  val logger:                LoggerLike,
+  accountService:            AccountService[Future],
   helpToSaveGetTransactions: HelpToSaveGetTransactions[Future],
-  authorisedWithIds: AuthorisedWithIds,
-  config: HelpToSaveControllerConfig
-)(implicit ec: ExecutionContext) extends BaseController with ControllerChecks with HelpToSaveActions {
+  authorisedWithIds:         AuthorisedWithIds,
+  config:                    HelpToSaveControllerConfig
+)(
+  implicit ec: ExecutionContext
+) extends BaseController
+    with ControllerChecks
+    with HelpToSaveActions {
   override def shuttering: Shuttering = config.shuttering
 
   private def orAccountNotFound[T: Writes](o: Option[T]): Result =
@@ -51,15 +54,18 @@ class HelpToSaveController
   override def getTransactions(ninoString: String): Action[AnyContent] =
     authorisedWithIds.async { implicit request: RequestWithIds[AnyContent] =>
       verifyingMatchingNino(ninoString) { verifiedUserNino =>
-        helpToSaveGetTransactions.getTransactions(verifiedUserNino).map(handlingErrors(txs => Ok(Json.toJson(txs.reverse))))
+        helpToSaveGetTransactions
+          .getTransactions(verifiedUserNino)
+          .map(handlingErrors(txs => Ok(Json.toJson(txs.reverse))))
       }
     }
 
-  override def getAccount(ninoString: String): Action[AnyContent] = authorisedWithIds.async { implicit request: RequestWithIds[AnyContent] =>
-    verifyingMatchingNino(ninoString) { nino =>
-      //noinspection ConvertibleToMethodValue
-      accountService.account(nino).map(handlingErrors(orAccountNotFound(_)))
-    }
+  override def getAccount(ninoString: String): Action[AnyContent] = authorisedWithIds.async {
+    implicit request: RequestWithIds[AnyContent] =>
+      verifyingMatchingNino(ninoString) { nino =>
+        //noinspection ConvertibleToMethodValue
+        accountService.account(nino).map(handlingErrors(orAccountNotFound(_)))
+      }
   }
 
   override def putSavingsGoal(ninoString: String): Action[SavingsGoal] =

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/HmrcNinoDefinition.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/HmrcNinoDefinition.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,5 +20,6 @@ import scala.util.matching.Regex
 
 object HmrcNinoDefinition {
   // CTO's HMRC-wide NINO regex
-  final val regex: Regex = "^((?!(BG|GB|KN|NK|NT|TN|ZZ)|(D|F|I|Q|U|V)[A-Z]|[A-Z](D|F|I|O|Q|U|V))[A-Z]{2})[0-9]{6}[A-D]?$".r
+  final val regex: Regex =
+    "^((?!(BG|GB|KN|NK|NT|TN|ZZ)|(D|F|I|Q|U|V)[A-Z]|[A-Z](D|F|I|O|Q|U|V))[A-Z]{2})[0-9]{6}[A-D]?$".r
 }

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/SandboxController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/SandboxController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,10 +30,12 @@ import uk.gov.hmrc.play.bootstrap.controller.BaseController
 import scala.concurrent.Future
 
 class SandboxController(
-  val logger: LoggerLike,
-  config: HelpToSaveControllerConfig,
+  val logger:  LoggerLike,
+  config:      HelpToSaveControllerConfig,
   sandboxData: SandboxData
-) extends BaseController with ControllerChecks with HelpToSaveActions {
+) extends BaseController
+    with ControllerChecks
+    with HelpToSaveActions {
   override def shuttering: Shuttering = config.shuttering
 
   override def getTransactions(ninoString: String): Action[AnyContent] = Action.async { implicit request =>

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/StartupController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/StartupController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,20 +26,21 @@ import uk.gov.hmrc.play.bootstrap.controller.BaseController
 import scala.concurrent.{ExecutionContext, Future}
 
 class StartupController(
-  userService: UserService[Future],
+  userService:       UserService[Future],
   authorisedWithIds: AuthorisedWithIds,
-  config: StartupControllerConfig
-)(implicit ec: ExecutionContext) extends BaseController {
+  config:            StartupControllerConfig
+)(implicit ec:       ExecutionContext)
+    extends BaseController {
 
   val startup: Action[AnyContent] = if (!config.shuttering.shuttered) {
     authorisedWithIds.async { implicit request =>
       val responseF = userService.userDetails(request.nino).map { userOrError =>
         StartupResponse(
-          shuttering = config.shuttering,
-          infoUrl = Some(config.helpToSaveInfoUrl),
-          accessAccountUrl = Some(config.helpToSaveAccessAccountUrl),
-          user = userOrError.right.toOption,
-          userError = userOrError.left.toOption,
+          shuttering         = config.shuttering,
+          infoUrl            = Some(config.helpToSaveInfoUrl),
+          accessAccountUrl   = Some(config.helpToSaveAccessAccountUrl),
+          user               = userOrError.right.toOption,
+          userError          = userOrError.left.toOption,
           supportFormEnabled = config.supportFormEnabled
         )
       }
@@ -49,11 +50,11 @@ class StartupController(
     Action { implicit request =>
       val response =
         StartupResponse(
-          shuttering = config.shuttering,
-          infoUrl = None,
-          accessAccountUrl = None,
-          user = None,
-          userError = None,
+          shuttering         = config.shuttering,
+          infoUrl            = None,
+          accessAccountUrl   = None,
+          user               = None,
+          userError          = None,
           supportFormEnabled = config.supportFormEnabled
         )
 

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/test/TestController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/test/TestController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/mobilehelptosave/domain/Account.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/domain/Account.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,11 @@ import play.api.LoggerLike
 import play.api.libs.json._
 import uk.gov.hmrc.mobilehelptosave.connectors.{HelpToSaveAccount, HelpToSaveBonusTerm}
 
-
 case class BonusTerm(
-  bonusEstimate: BigDecimal,
-  bonusPaid: BigDecimal,
-  endDate: LocalDate,
-  bonusPaidOnOrAfterDate: LocalDate,
+  bonusEstimate:                 BigDecimal,
+  bonusPaid:                     BigDecimal,
+  endDate:                       LocalDate,
+  bonusPaidOnOrAfterDate:        LocalDate,
   balanceMustBeMoreThanForBonus: BigDecimal
 )
 
@@ -45,70 +44,58 @@ object Blocking {
 object CurrentBonusTerm extends Enumeration {
   val First, Second, AfterFinalTerm = Value
 
-  implicit val reads : Reads[Value]  = Reads.enumNameReads(CurrentBonusTerm)
+  implicit val reads:  Reads[Value]  = Reads.enumNameReads(CurrentBonusTerm)
   implicit val writes: Writes[Value] = Writes.enumNameWrites
-
 }
 
 case class Account(
-  number: String,
-  openedYearMonth: YearMonth,
-
-  isClosed: Boolean,
-
-  blocked: Blocking,
-
-  balance: BigDecimal,
-
-  paidInThisMonth: BigDecimal,
-  canPayInThisMonth: BigDecimal,
-  maximumPaidInThisMonth: BigDecimal,
-  thisMonthEndDate: LocalDate,
+  number:                    String,
+  openedYearMonth:           YearMonth,
+  isClosed:                  Boolean,
+  blocked:                   Blocking,
+  balance:                   BigDecimal,
+  paidInThisMonth:           BigDecimal,
+  canPayInThisMonth:         BigDecimal,
+  maximumPaidInThisMonth:    BigDecimal,
+  thisMonthEndDate:          LocalDate,
   nextPaymentMonthStartDate: Option[LocalDate],
-
-  accountHolderName: String,
-  accountHolderEmail: Option[String],
-
-  bonusTerms: Seq[BonusTerm],
-  currentBonusTerm: CurrentBonusTerm.Value,
-
-  closureDate: Option[LocalDate] = None,
-  closingBalance: Option[BigDecimal] = None,
-
-  inAppPaymentsEnabled: Boolean,
-
+  accountHolderName:         String,
+  accountHolderEmail:        Option[String],
+  bonusTerms:                Seq[BonusTerm],
+  currentBonusTerm:          CurrentBonusTerm.Value,
+  closureDate:               Option[LocalDate] = None,
+  closingBalance:            Option[BigDecimal] = None,
+  inAppPaymentsEnabled:      Boolean,
   // This field is populated from the application config
   savingsGoalsEnabled: Boolean = false,
-
   // This field is populated from the mongo repository
-  savingsGoal: Option[SavingsGoal] = None,
-
+  savingsGoal:          Option[SavingsGoal] = None,
   daysRemainingInMonth: Int
 )
 
 object Account {
   implicit val yearMonthFormat: Format[YearMonth] = uk.gov.hmrc.mobilehelptosave.json.Formats.JodaYearMonthFormat
-  implicit val format         : OFormat[Account]  = Json.format[Account]
+  implicit val format:          OFormat[Account]  = Json.format[Account]
 
   def apply(h: HelpToSaveAccount, inAppPaymentsEnabled: Boolean, logger: LoggerLike, now: LocalDate): Account = Account(
-    number = h.accountNumber,
-    openedYearMonth = h.openedYearMonth,
-    isClosed = h.isClosed,
-    blocked = h.blocked,
-    balance = h.balance,
-    paidInThisMonth = h.paidInThisMonth,
-    canPayInThisMonth = h.canPayInThisMonth,
-    maximumPaidInThisMonth = h.maximumPaidInThisMonth,
-    thisMonthEndDate = h.thisMonthEndDate,
+    number                    = h.accountNumber,
+    openedYearMonth           = h.openedYearMonth,
+    isClosed                  = h.isClosed,
+    blocked                   = h.blocked,
+    balance                   = h.balance,
+    paidInThisMonth           = h.paidInThisMonth,
+    canPayInThisMonth         = h.canPayInThisMonth,
+    maximumPaidInThisMonth    = h.maximumPaidInThisMonth,
+    thisMonthEndDate          = h.thisMonthEndDate,
     nextPaymentMonthStartDate = nextPaymentMonthStartDate(h),
-    accountHolderName = h.accountHolderForename + " " + h.accountHolderSurname,
-    accountHolderEmail = h.accountHolderEmail,
-    bonusTerms = bonusTerms(h, logger),
-    currentBonusTerm = currentBonusTerm(h),
-    closureDate = h.closureDate,
-    closingBalance = h.closingBalance,
-    inAppPaymentsEnabled = inAppPaymentsEnabled,
-    daysRemainingInMonth = calculateDaysRemainingInMonth(now, h)
+    accountHolderName         = h.accountHolderForename + " " + h.accountHolderSurname,
+    accountHolderEmail        = h.accountHolderEmail,
+    bonusTerms                = bonusTerms(h, logger),
+    currentBonusTerm          = currentBonusTerm(h),
+    closureDate               = h.closureDate,
+    closingBalance            = h.closingBalance,
+    inAppPaymentsEnabled      = inAppPaymentsEnabled,
+    daysRemainingInMonth      = calculateDaysRemainingInMonth(now, h)
   )
 
   /**
@@ -125,13 +112,12 @@ object Account {
   private def calculateDaysRemainingInMonth(now: LocalDate, h: HelpToSaveAccount): Int =
     Days.daysBetween(now, h.thisMonthEndDate).getDays + 1
 
-  private def nextPaymentMonthStartDate(h: HelpToSaveAccount) = {
+  private def nextPaymentMonthStartDate(h: HelpToSaveAccount) =
     if (h.thisMonthEndDate.isBefore(h.bonusTerms.last.endDate)) {
       Some(h.thisMonthEndDate.plusDays(1))
     } else {
       None
     }
-  }
 
   private def currentBonusTerm(h: HelpToSaveAccount) =
     if (h.thisMonthEndDate.isAfter(h.bonusTerms(1).endDate)) {
@@ -145,19 +131,21 @@ object Account {
   private def bonusTerms(h: HelpToSaveAccount, logger: LoggerLike): Seq[BonusTerm] = {
 
     def bonusTerm(htsTerm: HelpToSaveBonusTerm, balanceMustBeMoreThanForBonus: BigDecimal) = BonusTerm(
-      bonusEstimate = htsTerm.bonusEstimate,
-      bonusPaid = htsTerm.bonusPaid,
-      endDate = htsTerm.endDate,
-      bonusPaidOnOrAfterDate = htsTerm.bonusPaidOnOrAfterDate,
+      bonusEstimate                 = htsTerm.bonusEstimate,
+      bonusPaid                     = htsTerm.bonusPaid,
+      endDate                       = htsTerm.endDate,
+      bonusPaidOnOrAfterDate        = htsTerm.bonusPaidOnOrAfterDate,
       balanceMustBeMoreThanForBonus = balanceMustBeMoreThanForBonus
     )
 
     if (h.bonusTerms.size > 2) {
-      logger.warn(s"Account contained ${h.bonusTerms.size} bonus terms, which is more than the expected 2 - discarding all but the first 2 terms")
+      logger.warn(
+        s"Account contained ${h.bonusTerms.size} bonus terms, which is more than the expected 2 - discarding all but the first 2 terms")
     }
 
     h.bonusTerms.take(2).foldLeft(Vector.empty[BonusTerm]) { (acc, htsTerm) =>
-      val balanceMustBeMoreThanForBonus: BigDecimal = acc.lastOption.fold(BigDecimal(0))(prevHtsTerm => prevHtsTerm.bonusEstimate * 2)
+      val balanceMustBeMoreThanForBonus: BigDecimal =
+        acc.lastOption.fold(BigDecimal(0))(prevHtsTerm => prevHtsTerm.bonusEstimate * 2)
 
       acc :+ bonusTerm(htsTerm, balanceMustBeMoreThanForBonus)
     }

--- a/app/uk/gov/hmrc/mobilehelptosave/domain/Account.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/domain/Account.scala
@@ -139,8 +139,7 @@ object Account {
     )
 
     if (h.bonusTerms.size > 2) {
-      logger.warn(
-        s"Account contained ${h.bonusTerms.size} bonus terms, which is more than the expected 2 - discarding all but the first 2 terms")
+      logger.warn(s"Account contained ${h.bonusTerms.size} bonus terms, which is more than the expected 2 - discarding all but the first 2 terms")
     }
 
     h.bonusTerms.take(2).foldLeft(Vector.empty[BonusTerm]) { (acc, htsTerm) =>

--- a/app/uk/gov/hmrc/mobilehelptosave/domain/ErrorBody.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/domain/ErrorBody.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/mobilehelptosave/domain/ErrorInfo.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/domain/ErrorInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/mobilehelptosave/domain/SavingsGoal.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/domain/SavingsGoal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/mobilehelptosave/domain/StartupResponse.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/domain/StartupResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,18 +19,18 @@ package uk.gov.hmrc.mobilehelptosave.domain
 import play.api.libs.json._
 
 case class StartupResponse(
-  shuttering: Shuttering,
-  infoUrl: Option[String],
-  accessAccountUrl: Option[String],
-  user: Option[UserDetails],
-  userError: Option[ErrorInfo],
+  shuttering:         Shuttering,
+  infoUrl:            Option[String],
+  accessAccountUrl:   Option[String],
+  user:               Option[UserDetails],
+  userError:          Option[ErrorInfo],
   supportFormEnabled: Boolean
 )
 
-case class Shuttering (
+case class Shuttering(
   shuttered: Boolean,
-  title: String,
-  message: String
+  title:     String,
+  message:   String
 )
 
 case object Shuttering {

--- a/app/uk/gov/hmrc/mobilehelptosave/domain/TransactionsDomain.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/domain/TransactionsDomain.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,19 +38,19 @@ object Operation {
   implicit val reads: Reads[Operation] = new Reads[Operation] {
     override def reads(json: JsValue): JsResult[Operation] = json match {
       case JsString("credit") => JsSuccess(Credit)
-      case JsString("debit") => JsSuccess(Debit)
-      case JsString(unknown) => JsError(s"[$unknown] in not a valid Operation e.g. [credit|debit]")
-      case unknown => JsError(s"Cannot parse $unknown to a valid Operation e.g. [credit|debit]")
+      case JsString("debit")  => JsSuccess(Debit)
+      case JsString(unknown)  => JsError(s"[$unknown] in not a valid Operation e.g. [credit|debit]")
+      case unknown            => JsError(s"Cannot parse $unknown to a valid Operation e.g. [credit|debit]")
     }
   }
 }
 
 case class Transaction(
-  operation:            Operation,
-  amount:               BigDecimal,
-  transactionDate:      LocalDate,
-  accountingDate:       LocalDate,
-  balanceAfter:         BigDecimal
+  operation:       Operation,
+  amount:          BigDecimal,
+  transactionDate: LocalDate,
+  accountingDate:  LocalDate,
+  balanceAfter:    BigDecimal
 )
 
 object Transaction {

--- a/app/uk/gov/hmrc/mobilehelptosave/domain/User.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/domain/User.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/mobilehelptosave/json/Formats.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/json/Formats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/mobilehelptosave/repository/IndexedMongoRepo.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/repository/IndexedMongoRepo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,12 +39,13 @@ import scala.concurrent.{ExecutionContext, Future}
   *
   */
 class IndexedMongoRepo[I, V: Manifest](
-  collectionName: String,
+  collectionName:     String,
   val indexFieldName: String,
-  unique:Boolean,
-  mongo: ReactiveMongoComponent
-)(implicit ec: ExecutionContext, iFormat: Format[I], tFormat: Format[V])
-  extends ReactiveRepository[V, BSONObjectID](collectionName, mongo.mongoConnector.db, tFormat) with AtomicUpdate[V] {
+  unique:             Boolean,
+  mongo:              ReactiveMongoComponent
+)(implicit ec:        ExecutionContext, iFormat: Format[I], tFormat: Format[V])
+    extends ReactiveRepository[V, BSONObjectID](collectionName, mongo.mongoConnector.db, tFormat)
+    with AtomicUpdate[V] {
 
   override def indexes: Seq[Index] = Seq(
     Index(Seq(indexFieldName -> IndexType.Text), name = Some(s"${indexFieldName}Idx"), unique = unique, sparse = true)
@@ -61,12 +62,11 @@ class IndexedMongoRepo[I, V: Manifest](
     * @param indexOf a function to extract the index value from the value being saved. If `V` contains the index
     *                then this is probably just a function to extract that index value.
     */
-  def set(value: V)(indexOf: V => I): Future[Unit] = {
+  def set(value: V)(indexOf: V => I): Future[Unit] =
     atomicUpsert(
       BSONDocument(indexFieldName -> Json.toJson(indexOf(value))),
-      BSONDocument("$set" -> Json.toJson(value))
+      BSONDocument("$set"         -> Json.toJson(value))
     ).void
-  }
 
   override def isInsertion(newRecordId: BSONObjectID, oldRecord: V): Boolean = false
 

--- a/app/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalRepoModel.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalRepoModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,18 +21,16 @@ import java.time.LocalDateTime
 import enumeratum.{Enum, EnumEntry, PlayLowercaseJsonEnum}
 import play.api.libs.json._
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.mobilehelptosave.repository.SavingsGoalEventType.findValues
 
 case class SavingsGoalRepoModel(nino: Nino, amount: Double, createdAt: LocalDateTime)
 
 object SavingsGoalRepoModel {
-  implicit val reads : Reads[SavingsGoalRepoModel]   = Json.reads[SavingsGoalRepoModel]
+  implicit val reads:  Reads[SavingsGoalRepoModel]   = Json.reads[SavingsGoalRepoModel]
   implicit val writes: OWrites[SavingsGoalRepoModel] = Json.writes[SavingsGoalRepoModel]
 
   implicit val format: Format[SavingsGoalRepoModel] =
     Format(reads, writes)
 }
-
 
 sealed trait SavingsGoalEventType extends EnumEntry
 
@@ -48,27 +46,27 @@ sealed trait SavingsGoalEvent {
   def nino: Nino
   def date: LocalDateTime
 }
-case class SavingsGoalSetEvent(nino: Nino, amount: Double, date: LocalDateTime) extends SavingsGoalEvent
-case class SavingsGoalDeleteEvent(nino: Nino, date: LocalDateTime) extends SavingsGoalEvent
+case class SavingsGoalSetEvent(nino:    Nino, amount: Double, date: LocalDateTime) extends SavingsGoalEvent
+case class SavingsGoalDeleteEvent(nino: Nino, date:   LocalDateTime) extends SavingsGoalEvent
 
 object SavingsGoalEvent {
-  val setEventFormat   : OFormat[SavingsGoalSetEvent]    = Json.format
+  val setEventFormat:    OFormat[SavingsGoalSetEvent]    = Json.format
   val deleteEventFormat: OFormat[SavingsGoalDeleteEvent] = Json.format
 
   val typeReads: Reads[SavingsGoalEventType] = (__ \ "type").read
 
   implicit val format: OFormat[SavingsGoalEvent] = new OFormat[SavingsGoalEvent] {
     override def writes(o: SavingsGoalEvent): JsObject = o match {
-      case ev: SavingsGoalSetEvent    => setEventFormat.writes(ev) + ("type" -> Json.toJson(SavingsGoalEventType.Set))
-      case ev: SavingsGoalDeleteEvent => deleteEventFormat.writes(ev) + ("type" -> Json.toJson(SavingsGoalEventType.Delete))
+      case ev: SavingsGoalSetEvent => setEventFormat.writes(ev) + ("type" -> Json.toJson(SavingsGoalEventType.Set))
+      case ev: SavingsGoalDeleteEvent =>
+        deleteEventFormat.writes(ev) + ("type" -> Json.toJson(SavingsGoalEventType.Delete))
     }
 
-    override def reads(json: JsValue): JsResult[SavingsGoalEvent] = {
+    override def reads(json: JsValue): JsResult[SavingsGoalEvent] =
       typeReads.reads(json) match {
         case JsSuccess(ev, _) => readEvent(ev, json)
-        case error: JsError   => error
+        case error: JsError => error
       }
-    }
 
     private def readEvent(ev: SavingsGoalEventType, json: JsValue): JsResult[SavingsGoalEvent] = ev match {
       case SavingsGoalEventType.Set    => setEventFormat.reads(json)

--- a/app/uk/gov/hmrc/mobilehelptosave/sandbox/SandboxData.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/sandbox/SandboxData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.mobilehelptosave.sandbox
 
-
 import org.joda.time.{LocalDate, YearMonth}
 import play.api.LoggerLike
 import uk.gov.hmrc.mobilehelptosave.config.SandboxDataConfig
@@ -24,66 +23,65 @@ import uk.gov.hmrc.mobilehelptosave.connectors.{HelpToSaveAccount, HelpToSaveBon
 import uk.gov.hmrc.mobilehelptosave.domain._
 import uk.gov.hmrc.mobilehelptosave.services.Clock
 
-
-case class SandboxData
-(
+case class SandboxData(
   logger: LoggerLike,
-  clock: Clock,
+  clock:  Clock,
   config: SandboxDataConfig
 ) {
 
-  private def today: LocalDate = clock.now().toLocalDate
-  private def openedDate: LocalDate = today.minusMonths(7)
-  private def endOfMonth: LocalDate = today.dayOfMonth.withMaximumValue
-  private def startOfFirstTerm: LocalDate = openedDate.dayOfMonth.withMinimumValue
-  private def endOfFirstTerm: LocalDate = startOfFirstTerm.plusYears(2).minusDays(1)
+  private def today:             LocalDate = clock.now().toLocalDate
+  private def openedDate:        LocalDate = today.minusMonths(7)
+  private def endOfMonth:        LocalDate = today.dayOfMonth.withMaximumValue
+  private def startOfFirstTerm:  LocalDate = openedDate.dayOfMonth.withMinimumValue
+  private def endOfFirstTerm:    LocalDate = startOfFirstTerm.plusYears(2).minusDays(1)
   private def startOfSecondTerm: LocalDate = startOfFirstTerm.plusYears(2)
-  private def endOfSecondTerm: LocalDate = startOfSecondTerm.plusYears(2).minusDays(1)
+  private def endOfSecondTerm:   LocalDate = startOfSecondTerm.plusYears(2).minusDays(1)
 
   val account: Account = {
     Account(
       HelpToSaveAccount(
-        accountNumber = "1100000112057",
-        openedYearMonth = new YearMonth(openedDate.getYear, openedDate.getMonthOfYear),
-        isClosed = false,
-        blocked = Blocking(false),
-        balance = BigDecimal("220.50"),
-        paidInThisMonth = BigDecimal("20.50"),
-        canPayInThisMonth = BigDecimal("29.50"),
+        accountNumber          = "1100000112057",
+        openedYearMonth        = new YearMonth(openedDate.getYear, openedDate.getMonthOfYear),
+        isClosed               = false,
+        blocked                = Blocking(false),
+        balance                = BigDecimal("220.50"),
+        paidInThisMonth        = BigDecimal("20.50"),
+        canPayInThisMonth      = BigDecimal("29.50"),
         maximumPaidInThisMonth = BigDecimal("50.00"),
-        thisMonthEndDate = endOfMonth,
-        accountHolderForename = "Testfore",
-        accountHolderSurname = "Testsur",
-        accountHolderEmail = Some("testemail@example.com"),
+        thisMonthEndDate       = endOfMonth,
+        accountHolderForename  = "Testfore",
+        accountHolderSurname   = "Testsur",
+        accountHolderEmail     = Some("testemail@example.com"),
         bonusTerms = List(
           HelpToSaveBonusTerm(BigDecimal("110.25"), BigDecimal("0.00"), endOfFirstTerm, endOfFirstTerm.plusDays(1)),
           HelpToSaveBonusTerm(BigDecimal("0.00"), BigDecimal("0.00"), endOfSecondTerm, endOfSecondTerm.plusDays(1))
         ),
-        closureDate = None,
+        closureDate    = None,
         closingBalance = None
       ),
       inAppPaymentsEnabled = config.inAppPaymentsEnabled,
       logger,
-      new LocalDate(2018, 4, 30))
+      new LocalDate(2018, 4, 30)
+    )
   }
 
-  val transactions = Transactions(
-    {
-      Seq(
-        (0, 20.50, 220.50),
-        (1, 20.00, 200.00),
-        (1, 18.20, 180.00),
-        (2, 10.40, 161.80),
-        (3, 35.00, 151.40),
-        (3, 15.00, 116.40),
-        (4, 06.00, 101.40),
-        (5, 20.40, 95.40),
-        (5, 10.00, 75.00),
-        (6, 25.00, 65.00),
-        (7, 40.00, 40.00)
-      ) map { case (monthsAgo, creditAmount, balance) =>
+  val transactions = Transactions({
+    Seq(
+      (0, 20.50, 220.50),
+      (1, 20.00, 200.00),
+      (1, 18.20, 180.00),
+      (2, 10.40, 161.80),
+      (3, 35.00, 151.40),
+      (3, 15.00, 116.40),
+      (4, 06.00, 101.40),
+      (5, 20.40, 95.40),
+      (5, 10.00, 75.00),
+      (6, 25.00, 65.00),
+      (7, 40.00, 40.00)
+    ) map {
+      case (monthsAgo, creditAmount, balance) =>
         val date = today.minusMonths(monthsAgo)
         Transaction(Credit, BigDecimal(creditAmount), date, date, BigDecimal(balance))
-      }
-    })
+    }
+  })
 }

--- a/app/uk/gov/hmrc/mobilehelptosave/services/Clock.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/services/Clock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/mobilehelptosave/services/ProdUserService.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/services/ProdUserService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,14 +32,13 @@ trait UserService[F[_]] {
 }
 
 class ProdUserService(
-  logger: LoggerLike,
+  logger:              LoggerLike,
   helpToSaveConnector: HelpToSaveEnrolmentStatus[Future]
-)(implicit ec: ExecutionContext)
-  extends UserService[Future] {
-  def userDetails(nino: Nino)(implicit hc: HeaderCarrier): Future[Either[ErrorInfo, UserDetails]] = {
+)(implicit ec:         ExecutionContext)
+    extends UserService[Future] {
+  def userDetails(nino: Nino)(implicit hc: HeaderCarrier): Future[Either[ErrorInfo, UserDetails]] =
     EitherT(helpToSaveConnector.enrolmentStatus())
       .map(isEnrolled => if (isEnrolled) Enrolled else NotEnrolled)
       .map(state => UserDetails(state = state))
       .value
-  }
 }

--- a/app/uk/gov/hmrc/mobilehelptosave/services/package.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/services/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/mobilehelptosave/wiring/AppLoader.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/wiring/AppLoader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/mobilehelptosave/wiring/ServiceComponents.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/wiring/ServiceComponents.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,11 +47,17 @@ import scala.concurrent.{ExecutionContext, Future}
 trait SandboxRequestRouting {
   self: BuiltInComponents =>
   override lazy val httpRequestHandler: HttpRequestHandler =
-    new RoutingHttpRequestHandler(router, httpErrorHandler, httpConfiguration, new DefaultHttpFilters(httpFilters: _*), environment, configuration)
+    new RoutingHttpRequestHandler(
+      router,
+      httpErrorHandler,
+      httpConfiguration,
+      new DefaultHttpFilters(httpFilters: _*),
+      environment,
+      configuration)
 }
 
 class ServiceComponents(context: Context)
-  extends BuiltInComponentsFromContext(context)
+    extends BuiltInComponentsFromContext(context)
     with AhcWSComponents
     with SandboxRequestRouting {
 
@@ -59,50 +65,49 @@ class ServiceComponents(context: Context)
 
   lazy val prodLogger: LoggerLike = Logger
 
-  lazy val prefix          : String                           = "/"
-  lazy val sandboxRouter   : sandbox.Routes                   = wire[sandbox.Routes]
+  lazy val prefix:           String                           = "/"
+  lazy val sandboxRouter:    sandbox.Routes                   = wire[sandbox.Routes]
   lazy val definitionRouter: definition.Routes                = wire[definition.Routes]
-  lazy val healthRouter    : health2.Routes                   = wire[health2.Routes]
-  lazy val appRouter       : app.Routes                       = wire[app.Routes]
-  lazy val apiRouter       : api.Routes                       = wire[api.Routes]
-  lazy val testRouter      : _root_.test.Routes               = wire[_root_.test.Routes]
-  lazy val prodRoutes      : prod.Routes                      = wire[prod.Routes]
-  lazy val testOnlyRoutes  : testOnlyDoNotUseInAppConf.Routes = wire[testOnlyDoNotUseInAppConf.Routes]
+  lazy val healthRouter:     health2.Routes                   = wire[health2.Routes]
+  lazy val appRouter:        app.Routes                       = wire[app.Routes]
+  lazy val apiRouter:        api.Routes                       = wire[api.Routes]
+  lazy val testRouter:       _root_.test.Routes               = wire[_root_.test.Routes]
+  lazy val prodRoutes:       prod.Routes                      = wire[prod.Routes]
+  lazy val testOnlyRoutes:   testOnlyDoNotUseInAppConf.Routes = wire[testOnlyDoNotUseInAppConf.Routes]
 
   override lazy val router: Router =
     if (System.getProperty("application.router") == classOf[testOnlyDoNotUseInAppConf.Routes].getName) {
       prodLogger.info("Wiring in test-only routes")
       testOnlyRoutes
-    }
-    else prodRoutes
+    } else prodRoutes
 
   lazy val ws: DefaultHttpClient = wire[DefaultHttpClient]
 
-  lazy val clock      : Clock       = wire[ClockImpl]
-  lazy val metrics    : Metrics     = wire[MetricsImpl]
+  lazy val clock:       Clock       = wire[ClockImpl]
+  lazy val metrics:     Metrics     = wire[MetricsImpl]
   lazy val sandboxData: SandboxData = wire[SandboxData]
 
   lazy val authorisedWithIds: AuthorisedWithIds = wire[AuthorisedWithIdsImpl]
 
   lazy val helpToSaveConfig: MobileHelpToSaveConfig = wire[MobileHelpToSaveConfig]
 
-  lazy val helpToSaveConnector    : HelpToSaveConnectorImpl = wire[HelpToSaveConnectorImpl]
-  lazy val auditConnector         : AuditConnector          = wire[DefaultAuditConnector]
-  lazy val authConnector          : AuthConnector           = wire[DefaultAuthConnector]
+  lazy val helpToSaveConnector:     HelpToSaveConnectorImpl = wire[HelpToSaveConnectorImpl]
+  lazy val auditConnector:          AuditConnector          = wire[DefaultAuditConnector]
+  lazy val authConnector:           AuthConnector           = wire[DefaultAuthConnector]
   lazy val serviceLocatorConnector: ServiceLocatorConnector = wire[ApiServiceLocatorConnector]
 
-  lazy val userService   : UserService[Future]    = wire[ProdUserService]
+  lazy val userService:    UserService[Future]    = wire[ProdUserService]
   lazy val accountService: AccountService[Future] = wire[AccountServiceImpl[Future]]
 
-  lazy val mongo    : ReactiveMongoComponent       = wire[ReactiveMongoComponentImpl]
+  lazy val mongo:     ReactiveMongoComponent       = wire[ReactiveMongoComponentImpl]
   lazy val eventRepo: SavingsGoalEventRepo[Future] = wire[MongoSavingsGoalEventRepo]
 
-  lazy val startupController      : StartupController       = wire[StartupController]
-  lazy val helpToSaveController   : HelpToSaveController    = wire[HelpToSaveController]
+  lazy val startupController:       StartupController       = wire[StartupController]
+  lazy val helpToSaveController:    HelpToSaveController    = wire[HelpToSaveController]
   lazy val documentationController: DocumentationController = wire[DocumentationController]
-  lazy val metricsController      : MetricsController       = wire[MetricsController]
-  lazy val sandboxController      : SandboxController       = wire[SandboxController]
-  lazy val testController         : TestController          = wire[TestController]
+  lazy val metricsController:       MetricsController       = wire[MetricsController]
+  lazy val sandboxController:       SandboxController       = wire[SandboxController]
+  lazy val testController:          TestController          = wire[TestController]
 
   lazy val healthController: HealthController = wire[HealthController]
 

--- a/app/uk/gov/hmrc/mobilehelptosave/wiring/ServiceComponents.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/wiring/ServiceComponents.scala
@@ -47,19 +47,10 @@ import scala.concurrent.{ExecutionContext, Future}
 trait SandboxRequestRouting {
   self: BuiltInComponents =>
   override lazy val httpRequestHandler: HttpRequestHandler =
-    new RoutingHttpRequestHandler(
-      router,
-      httpErrorHandler,
-      httpConfiguration,
-      new DefaultHttpFilters(httpFilters: _*),
-      environment,
-      configuration)
+    new RoutingHttpRequestHandler(router, httpErrorHandler, httpConfiguration, new DefaultHttpFilters(httpFilters: _*), environment, configuration)
 }
 
-class ServiceComponents(context: Context)
-    extends BuiltInComponentsFromContext(context)
-    with AhcWSComponents
-    with SandboxRequestRouting {
+class ServiceComponents(context: Context) extends BuiltInComponentsFromContext(context) with AhcWSComponents with SandboxRequestRouting {
 
   implicit val ec: ExecutionContext = actorSystem.dispatcher
 

--- a/app/uk/gov/hmrc/play/encoding/UriPathEncoding.scala
+++ b/app/uk/gov/hmrc/play/encoding/UriPathEncoding.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val microservice = Project(appName, file("."))
     majorVersion := 0,
     unmanagedResourceDirectories in Compile += baseDirectory.value / "resources",
     PlayKeys.playDefaultPort := 8248,
-    // from https://github.com/typelevel/cats/blob/master/README.md
+    // based on https://tpolecat.github.io/2017/04/25/scalac-flags.html but cut down for scala 2.11
     scalacOptions ++= Seq(
       "-deprecation",
       "-encoding",
@@ -44,7 +44,7 @@ lazy val microservice = Project(appName, file("."))
       "-Ywarn-nullary-override",
       "-Ywarn-nullary-unit",
       "-Ywarn-numeric-widen",
-      //"-Ywarn-unused-import",
+      //"-Ywarn-unused-import", - does not work well with fatal-warnings because of play-generated sources
       "-Xfatal-warnings",
       "-Xlint"
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -31,33 +31,36 @@ lazy val microservice = Project(appName, file("."))
     // from https://github.com/typelevel/cats/blob/master/README.md
     scalacOptions ++= Seq(
       "-deprecation",
-      "-encoding", "UTF-8",
+      "-encoding",
+      "UTF-8",
       "-language:higherKinds",
       "-language:postfixOps",
       "-feature",
       "-Ypartial-unification",
-      "-Ywarn-dead-code",                 
+      "-Ywarn-dead-code",
       "-Ywarn-value-discard",
-      "-Ywarn-inaccessible",             
-      "-Ywarn-infer-any",            
-      "-Ywarn-nullary-override",       
-      "-Ywarn-nullary-unit",            
-      "-Ywarn-numeric-widen",             
-      //"-Ywarn-unused-import",            
+      "-Ywarn-inaccessible",
+      "-Ywarn-infer-any",
+      "-Ywarn-nullary-override",
+      "-Ywarn-nullary-unit",
+      "-Ywarn-numeric-widen",
+      //"-Ywarn-unused-import",
+      "-Xfatal-warnings",
       "-Xlint"
     ),
     addCommandAlias("testAll", ";reload;test;it:test")
   )
   .settings(evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false))
-  .settings(unmanagedSourceDirectories in Test += baseDirectory.value / "testcommon"
-  )
+  .settings(unmanagedSourceDirectories in Test += baseDirectory.value / "testcommon")
   .configs(IntegrationTest)
   .settings(inConfig(IntegrationTest)(Defaults.itSettings): _*)
   .settings(
-      unmanagedSourceDirectories in IntegrationTest := (baseDirectory in IntegrationTest) (base => Seq(
-      base / "it",
-      base / "testcommon"
-    )).value: _*
+    unmanagedSourceDirectories in IntegrationTest := (baseDirectory in IntegrationTest)(
+      base =>
+        Seq(
+          base / "it",
+          base / "testcommon"
+      )).value: _*
   )
   .settings(
     Keys.fork in IntegrationTest := false,
@@ -70,7 +73,7 @@ lazy val microservice = Project(appName, file("."))
       Resolver.bintrayRepo("hmrc", "releases"),
       Resolver.jcenterRepo
     ),
-    addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.9"),
-    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4"),
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
+    addCompilerPlugin("org.spire-math"  %% "kind-projector"     % "0.9.9"),
+    addCompilerPlugin("com.olegpy"      %% "better-monadic-for" % "0.2.4"),
+    addCompilerPlugin("org.scalamacros" % "paradise"            % "2.1.1" cross CrossVersion.full)
   )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2018 HM Revenue & Customs
+# Copyright 2019 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/it/org/scalatestplus/play/components/OneAppPerSuiteWithComponents.scala
+++ b/it/org/scalatestplus/play/components/OneAppPerSuiteWithComponents.scala
@@ -1,137 +1,135 @@
 package org.scalatestplus.play.components
 
 import org.scalatest.TestSuite
-import org.scalatestplus.play.{ BaseOneAppPerSuite, FakeApplicationFactory }
+import org.scalatestplus.play.{BaseOneAppPerSuite, FakeApplicationFactory}
 import play.api.Application
 
 /**
- * An extension of [[BaseOneAppPerSuite]] providing Compile-time DI.
- *
- * Provides a new `Application` instance per ScalaTest `Suite`.
- *
- * By default, this trait creates a new `Application` for the `Suite` according to the components defined in the test.
- *
- * This `TestSuiteMixin` trait's overridden `run` method calls `Play.start`, passing in the
- * `Application` provided by `app`, before executing the `Suite` via a call to `super.run`.
- * In addition, it places a reference to the `Application` provided by `app` into the `ConfigMap`
- * under the key `org.scalatestplus.play.app`.  This allows any nested `Suite`s to access the `Suite`'s
- * `Application` as well, most easily by having the nested `Suite`s mix in the
- * [[org.scalatestplus.play.ConfiguredApp ConfiguredApp]] trait.  On the status returned by `super.run`, this
- * trait's overridden `run` method registers a call to `Play.stop` to be executed when the `Status`
- * completes, and returns the same `Status`. This ensure the `Application` will continue to execute until
- * all nested suites have completed, after which the `Application` will be stopped.
- *
- * Here's an example that demonstrates some of the services provided by this trait:
- *
- * <pre class="stHighlight">
- * import org.scalatestplus.play.PlaySpec
- * import OneServerPerSuiteWithComponents
- * import play.api._
- * import play.api.mvc.Result
- * import play.api.test.Helpers._
- * import play.api.test.{FakeRequest, Helpers}
- *
- * import scala.concurrent.Future
- *
- * class ExampleComponentsSpec extends PlaySpec with OneServerPerSuiteWithComponents {
- *
- *   override def components: BuiltInComponents = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
- *
- *     import play.api.mvc.Results
- *     import play.api.routing.Router
- *     import play.api.routing.sird._
- *
- *     lazy val router: Router = Router.from({
- *       case GET(p"/") => defaultActionBuilder {
- *         Results.Ok("success!")
- *       }
- *     })
- *
- *     override lazy val configuration: Configuration = context.initialConfiguration ++ Configuration("foo" -> "bar", "ehcacheplugin" -> "disabled")
- *   }
- *
- *   "The OneServerPerSuiteWithComponents trait" must {
- *     "provide an Application" in {
- *       import play.api.test.Helpers.{GET, route}
- *       val Some(result: Future[Result]) = route(app, FakeRequest(GET, "/"))
- *       Helpers.contentAsString(result) must be("success!")
- *     }
- *     "override the configuration" in {
- *       app.configuration.getOptional[String]("foo") mustBe Some("bar")
- *     }
- *   }
- * }
- * </pre>
- *
- * If you have many tests that can share the same `Application`, and you don't want to put them all into one
- * test class, you can place them into different `Suite` classes.
- * These will be your nested suites. Create a master suite that extends `OneAppPerSuiteWithComponents` and declares the nested
- * `Suite`s. Annotate the nested suites with `@DoNotDiscover` and have them extend `ConfiguredApp`. Here's an example:
- *
- * <pre class="stHighlight">
- * import org.scalatest.{DoNotDiscover, Suites, TestSuite}
- * import OneAppPerSuiteWithComponents
- * import org.scalatestplus.play.{ConfiguredApp, PlaySpec}
- * import play.api._
- * import play.api.mvc.Result
- * import play.api.test.Helpers._
- * import play.api.test.{FakeRequest, Helpers}
- *
- * import scala.concurrent.Future
- *
- *
- * class NestedExampleSpec extends Suites(
- *   new OneSpec,
- *   new TwoSpec,
- *   new RedSpec,
- *   new BlueSpec
- * ) with OneAppPerSuiteWithComponents with TestSuite {
- *   // Override fakeApplication if you need an Application with other than non-default parameters.
- *   override def components: BuiltInComponents = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
- *
- *     import play.api.mvc.Results
- *     import play.api.routing.Router
- *     import play.api.routing.sird._
- *
- *     lazy val router: Router = Router.from({
- *       case GET(p"/") => defaultActionBuilder {
- *         Results.Ok("success!")
- *       }
- *     })
- *
- *     override lazy val configuration: Configuration = context.initialConfiguration ++ Configuration("ehcacheplugin" -> "disabled")
- *
- *   }
- * }
- *
- * // These are the nested suites
- * @DoNotDiscover class OneSpec extends PlaySpec with ConfiguredApp {
- *   "OneSpec" must {
- *     "make the Application available implicitly" in {
- *       def getConfig(key: String)(implicit app: Application) = app.configuration.getOptional[String](key)
- *
- *       getConfig("ehcacheplugin") mustBe Some("disabled")
- *     }
- *   }
- *
- * }
- *
- * @DoNotDiscover class TwoSpec extends PlaySpec with ConfiguredApp
- *
- * @DoNotDiscover class RedSpec extends PlaySpec with ConfiguredApp
- *
- * @DoNotDiscover class BlueSpec extends PlaySpec with ConfiguredApp {
- *
- *   "The NestedExampleSpec" must {
- *     "provide an Application" in {
- *       import play.api.test.Helpers.{ GET, route }
- *       val Some(result: Future[Result]) = route(app, FakeRequest(GET, "/"))
- *       Helpers.contentAsString(result) must be("success!")
- *     }
- *   }
- * }
- * </pre>
- */
+  * An extension of [[BaseOneAppPerSuite]] providing Compile-time DI.
+  *
+  * Provides a new `Application` instance per ScalaTest `Suite`.
+  *
+  * By default, this trait creates a new `Application` for the `Suite` according to the components defined in the test.
+  *
+  * This `TestSuiteMixin` trait's overridden `run` method calls `Play.start`, passing in the
+  * `Application` provided by `app`, before executing the `Suite` via a call to `super.run`.
+  * In addition, it places a reference to the `Application` provided by `app` into the `ConfigMap`
+  * under the key `org.scalatestplus.play.app`.  This allows any nested `Suite`s to access the `Suite`'s
+  * `Application` as well, most easily by having the nested `Suite`s mix in the
+  * [[org.scalatestplus.play.ConfiguredApp ConfiguredApp]] trait.  On the status returned by `super.run`, this
+  * trait's overridden `run` method registers a call to `Play.stop` to be executed when the `Status`
+  * completes, and returns the same `Status`. This ensure the `Application` will continue to execute until
+  * all nested suites have completed, after which the `Application` will be stopped.
+  *
+  * Here's an example that demonstrates some of the services provided by this trait:
+  *
+  * <pre class="stHighlight">
+  * import org.scalatestplus.play.PlaySpec
+  * import OneServerPerSuiteWithComponents
+  * import play.api._
+  * import play.api.mvc.Result
+  * import play.api.test.Helpers._
+  * import play.api.test.{FakeRequest, Helpers}
+  *
+  * import scala.concurrent.Future
+  *
+  * class ExampleComponentsSpec extends PlaySpec with OneServerPerSuiteWithComponents {
+  *
+  *   override def components: BuiltInComponents = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
+  *
+  *     import play.api.mvc.Results
+  *     import play.api.routing.Router
+  *     import play.api.routing.sird._
+  *
+  *     lazy val router: Router = Router.from({
+  *       case GET(p"/") => defaultActionBuilder {
+  *         Results.Ok("success!")
+  *       }
+  *     })
+  *
+  *     override lazy val configuration: Configuration = context.initialConfiguration ++ Configuration("foo" -> "bar", "ehcacheplugin" -> "disabled")
+  *   }
+  *
+  *   "The OneServerPerSuiteWithComponents trait" must {
+  *     "provide an Application" in {
+  *       import play.api.test.Helpers.{GET, route}
+  *       val Some(result: Future[Result]) = route(app, FakeRequest(GET, "/"))
+  *       Helpers.contentAsString(result) must be("success!")
+  *     }
+  *     "override the configuration" in {
+  *       app.configuration.getOptional[String]("foo") mustBe Some("bar")
+  *     }
+  *   }
+  * }
+  * </pre>
+  *
+  * If you have many tests that can share the same `Application`, and you don't want to put them all into one
+  * test class, you can place them into different `Suite` classes.
+  * These will be your nested suites. Create a master suite that extends `OneAppPerSuiteWithComponents` and declares the nested
+  * `Suite`s. Annotate the nested suites with `@DoNotDiscover` and have them extend `ConfiguredApp`. Here's an example:
+  *
+  * <pre class="stHighlight">
+  * import org.scalatest.{DoNotDiscover, Suites, TestSuite}
+  * import OneAppPerSuiteWithComponents
+  * import org.scalatestplus.play.{ConfiguredApp, PlaySpec}
+  * import play.api._
+  * import play.api.mvc.Result
+  * import play.api.test.Helpers._
+  * import play.api.test.{FakeRequest, Helpers}
+  *
+  * import scala.concurrent.Future
+  *
+  *
+  * class NestedExampleSpec extends Suites(
+  *   new OneSpec,
+  *   new TwoSpec,
+  *   new RedSpec,
+  *   new BlueSpec
+  * ) with OneAppPerSuiteWithComponents with TestSuite {
+  *   // Override fakeApplication if you need an Application with other than non-default parameters.
+  *   override def components: BuiltInComponents = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
+  *
+  *     import play.api.mvc.Results
+  *     import play.api.routing.Router
+  *     import play.api.routing.sird._
+  *
+  *     lazy val router: Router = Router.from({
+  *       case GET(p"/") => defaultActionBuilder {
+  *         Results.Ok("success!")
+  *       }
+  *     })
+  *
+  *     override lazy val configuration: Configuration = context.initialConfiguration ++ Configuration("ehcacheplugin" -> "disabled")
+  *
+  *   }
+  * }
+  *
+  * // These are the nested suites
+  *
+  * @DoNotDiscover class OneSpec extends PlaySpec with ConfiguredApp {
+  *   "OneSpec" must {
+  *     "make the Application available implicitly" in {
+  *       def getConfig(key: String)(implicit app: Application) = app.configuration.getOptional[String](key)
+  *
+  *       getConfig("ehcacheplugin") mustBe Some("disabled")
+  *     }
+  *   }
+  *
+  * }
+  * @DoNotDiscover class TwoSpec extends PlaySpec with ConfiguredApp
+  * @DoNotDiscover class RedSpec extends PlaySpec with ConfiguredApp
+  * @DoNotDiscover class BlueSpec extends PlaySpec with ConfiguredApp {
+  *
+  *   "The NestedExampleSpec" must {
+  *     "provide an Application" in {
+  *       import play.api.test.Helpers.{ GET, route }
+  *       val Some(result: Future[Result]) = route(app, FakeRequest(GET, "/"))
+  *       Helpers.contentAsString(result) must be("success!")
+  *     }
+  *   }
+  * }
+  * </pre>
+  */
 trait OneAppPerSuiteWithComponents
     extends BaseOneAppPerSuite
     with WithApplicationComponents

--- a/it/org/scalatestplus/play/components/OneAppPerTestWithComponents.scala
+++ b/it/org/scalatestplus/play/components/OneAppPerTestWithComponents.scala
@@ -1,66 +1,67 @@
 package org.scalatestplus.play.components
 
-import org.scalatest.{ TestSuite, TestSuiteMixin }
-import org.scalatestplus.play.{ BaseOneAppPerTest, FakeApplicationFactory }
+import org.scalatest.{TestSuite, TestSuiteMixin}
+import org.scalatestplus.play.{BaseOneAppPerTest, FakeApplicationFactory}
 import play.api.Application
 
 /**
- * An extension of [[BaseOneAppPerTest]] providing Compile-time DI.
- *
- * Trait that provides a new `Application` instance for each test.
- *
- * This `TestSuiteMixin` trait's overridden `withFixture` method creates a new `Application`
- * before each test and ensures it is cleaned up after the test has completed. You can
- * access the `Application` from your tests as method `app` (which is marked implicit).
- *
- * By default, this trait creates a new `Application` for each test according to the components defined in the test.
- *
- * Here's an example that demonstrates some of the services provided by this trait:
- *
- * <pre class="stHighlight">
- * import org.scalatestplus.play.PlaySpec
- * import OneAppPerTestWithComponents
- * import play.api._
- * import play.api.mvc.Result
- * import play.api.test.Helpers._
- * import play.api.test.{FakeRequest, Helpers}
- *
- * import scala.concurrent.Future
- *
- * class ExampleComponentsSpec extends PlaySpec with OneAppPerTestWithComponents {
- *
- *   override def components: BuiltInComponents = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
- *
- *     import play.api.mvc.Results
- *     import play.api.routing.Router
- *     import play.api.routing.sird._
- *
- *     lazy val router: Router = Router.from({
- *       case GET(p"/") => defaultActionBuilder {
- *         Results.Ok("success!")
- *       }
- *     })
- *
- *     override lazy val configuration: Configuration = context.initialConfiguration ++ Configuration("foo" -> "bar", "ehcacheplugin" -> "disabled")
- *   }
- *
- *   "The OneAppPerTestWithComponents trait" must {
- *     "provide an Application" in {
- *       import play.api.test.Helpers.{GET, route}
- *       val Some(result: Future[Result]) = route(app, FakeRequest(GET, "/"))
- *       Helpers.contentAsString(result) must be("success!")
- *     }
- *     "override the configuration" in {
- *       app.configuration.getOptional[String]("foo") mustBe Some("bar")
- *     }
- *   }
- * }
- * </pre>
- */
+  * An extension of [[BaseOneAppPerTest]] providing Compile-time DI.
+  *
+  * Trait that provides a new `Application` instance for each test.
+  *
+  * This `TestSuiteMixin` trait's overridden `withFixture` method creates a new `Application`
+  * before each test and ensures it is cleaned up after the test has completed. You can
+  * access the `Application` from your tests as method `app` (which is marked implicit).
+  *
+  * By default, this trait creates a new `Application` for each test according to the components defined in the test.
+  *
+  * Here's an example that demonstrates some of the services provided by this trait:
+  *
+  * <pre class="stHighlight">
+  * import org.scalatestplus.play.PlaySpec
+  * import OneAppPerTestWithComponents
+  * import play.api._
+  * import play.api.mvc.Result
+  * import play.api.test.Helpers._
+  * import play.api.test.{FakeRequest, Helpers}
+  *
+  * import scala.concurrent.Future
+  *
+  * class ExampleComponentsSpec extends PlaySpec with OneAppPerTestWithComponents {
+  *
+  *   override def components: BuiltInComponents = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
+  *
+  *     import play.api.mvc.Results
+  *     import play.api.routing.Router
+  *     import play.api.routing.sird._
+  *
+  *     lazy val router: Router = Router.from({
+  *       case GET(p"/") => defaultActionBuilder {
+  *         Results.Ok("success!")
+  *       }
+  *     })
+  *
+  *     override lazy val configuration: Configuration = context.initialConfiguration ++ Configuration("foo" -> "bar", "ehcacheplugin" -> "disabled")
+  *   }
+  *
+  *   "The OneAppPerTestWithComponents trait" must {
+  *     "provide an Application" in {
+  *       import play.api.test.Helpers.{GET, route}
+  *       val Some(result: Future[Result]) = route(app, FakeRequest(GET, "/"))
+  *       Helpers.contentAsString(result) must be("success!")
+  *     }
+  *     "override the configuration" in {
+  *       app.configuration.getOptional[String]("foo") mustBe Some("bar")
+  *     }
+  *   }
+  * }
+  * </pre>
+  */
 trait OneAppPerTestWithComponents
     extends BaseOneAppPerTest
     with WithApplicationComponents
-    with FakeApplicationFactory with TestSuiteMixin {
+    with FakeApplicationFactory
+    with TestSuiteMixin {
   this: TestSuite =>
 
   override def fakeApplication(): Application = newApplication

--- a/it/org/scalatestplus/play/components/OneServerPerSuiteWithComponents.scala
+++ b/it/org/scalatestplus/play/components/OneServerPerSuiteWithComponents.scala
@@ -1,147 +1,145 @@
 package org.scalatestplus.play.components
 
 import org.scalatest.TestSuite
-import org.scalatestplus.play.{ BaseOneServerPerSuite, FakeApplicationFactory }
+import org.scalatestplus.play.{BaseOneServerPerSuite, FakeApplicationFactory}
 import play.api.Application
 
 /**
- * An extension of [[BaseOneServerPerSuite]] providing Compile-time DI.
- *
- * Trait that provides a new `Application` and running `TestServer` instance per ScalaTest `Suite`.
- *
- * By default, this trait creates a new `Application` for the `Suite` according to the components defined in the test, this
- * is made available via the `app` field defined in this trait and a new `TestServer` for the `Suite` using the port number provided by
- * its `port` field and the `Application` provided by its `app` field. If your `Suite` needs a different port number,
- * override `port`.
- *
- * This `TestSuiteMixin` trait's overridden `run` method calls `start` on the `TestServer`
- * before executing the `Suite` via a call to `super.run`.
- * In addition, it places a reference to the `Application` provided by `app` into the `ConfigMap`
- * under the key `org.scalatestplus.play.app` and to the port number provided by `port` under the key
- * `org.scalatestplus.play.port`.  This allows any nested `Suite`s to access the `Suite`'s
- * `Application` and port number as well, most easily by having the nested `Suite`s mix in the
- * [[org.scalatestplus.play.ConfiguredServer ConfiguredServer]] trait. On the status returned by `super.run`, this
- * trait's overridden `run` method registers a call to `stop` on the `TestServer` to be executed when the `Status`
- * completes, and returns the same `Status`. This ensure the `TestServer` will continue to execute until
- * all nested suites have completed, after which the `TestServer` will be stopped.
- *
- * Here's an example that demonstrates some of the services provided by this trait:
- *
- * <pre class="stHighlight">
- * import org.scalatestplus.play.PlaySpec
- * import OneServerPerSuiteWithComponents
- * import play.api._
- * import play.api.mvc.Result
- * import play.api.test.Helpers._
- * import play.api.test.{FakeRequest, Helpers}
- *
- * import scala.concurrent.Future
- *
- * class ExampleComponentsSpec extends PlaySpec with OneServerPerSuiteWithComponents {
- *
- *   override def components: BuiltInComponents = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
- *
- *     import play.api.mvc.Results
- *     import play.api.routing.Router
- *     import play.api.routing.sird._
- *
- *     lazy val router: Router = Router.from({
- *       case GET(p"/") => defaultActionBuilder {
- *         Results.Ok("success!")
- *       }
- *     })
- *
- *     override lazy val configuration: Configuration = context.initialConfiguration ++ Configuration("foo" -> "bar", "ehcacheplugin" -> "disabled")
- *   }
- *
- *   "The OneServerPerSuiteWithComponents trait" must {
- *     "provide an Application" in {
- *       import play.api.test.Helpers.{GET, route}
- *       val Some(result: Future[Result]) = route(app, FakeRequest(GET, "/"))
- *       Helpers.contentAsString(result) must be("success!")
- *     }
- *     "override the configuration" in {
- *       app.configuration.getOptional[String]("foo") mustBe Some("bar")
- *     }
- *   }
- * }
- * </pre>
- *
- * If you have many tests that can share the same `Application` and `TestServer`, and you don't want to put them all into one
- * test class, you can place them into different `Suite` classes.
- * These will be your nested suites. Create a master suite that extends `OneServerPerSuite` and declares the nested
- * `Suite`s. Annotate the nested suites with `@DoNotDiscover` and have them extend `ConfiguredServer`. Here's an example:
- *
- * <pre class="stHighlight">
- * import org.scalatest.{ DoNotDiscover, Suites, TestSuite }
- * import org.scalatestplus.play.components._
- * import org.scalatestplus.play.{ ConfiguredServer, PlaySpec }
- * import play.api._
- * import play.api.mvc.Result
- * import play.api.test.Helpers._
- * import play.api.test.{ FakeRequest, Helpers }
- *
- * import scala.concurrent.Future
- *
- * class NestedExampleSpec extends Suites(
- *   new OneSpec,
- *   new TwoSpec,
- *   new RedSpec,
- *   new BlueSpec
- * ) with OneServerPerSuiteWithComponents with TestSuite {
- *   // Override fakeApplication if you need an Application with other than non-default parameters.
- *   override def components: BuiltInComponents = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
- *
- *     import play.api.mvc.Results
- *     import play.api.routing.Router
- *     import play.api.routing.sird._
- *
- *     lazy val router: Router = Router.from({
- *       case GET(p"/") => defaultActionBuilder {
- *         Results.Ok("success!")
- *       }
- *     })
- *
- *     override lazy val configuration: Configuration = context.initialConfiguration ++ Configuration("ehcacheplugin" -> "disabled")
- *
- *   }
- * }
- *
- * // These are the nested suites
- * @DoNotDiscover class OneSpec extends PlaySpec with ConfiguredServer {
- *   "OneSpec" must {
- *     "make the Application available implicitly" in {
- *       def getConfig(key: String)(implicit app: Application) = app.configuration.getOptional[String](key)
- *
- *       getConfig("ehcacheplugin") mustBe Some("disabled")
- *     }
- *   }
- *
- * }
- *
- * @DoNotDiscover class TwoSpec extends PlaySpec with ConfiguredServer
- *
- * @DoNotDiscover class RedSpec extends PlaySpec with ConfiguredServer
- *
- * @DoNotDiscover class BlueSpec extends PlaySpec with ConfiguredServer {
- *
- *   "The NestedExampleSpeccc" must {
- *     "provide an Application" in {
- *       import play.api.test.Helpers.{ GET, route }
- *       val Some(result: Future[Result]) = route(app, FakeRequest(GET, "/"))
- *       Helpers.contentAsString(result) must be("success!")
- *     }
- *     "provide an actual running server" in {
- *       import java.net._
- *       val url = new URL("http://localhost:" + port + "/boum")
- *       val con = url.openConnection().asInstanceOf[HttpURLConnection]
- *       try con.getResponseCode mustBe 404
- *       finally con.disconnect()
- *     }
- *   }
- * }
- * </pre>
- */
+  * An extension of [[BaseOneServerPerSuite]] providing Compile-time DI.
+  *
+  * Trait that provides a new `Application` and running `TestServer` instance per ScalaTest `Suite`.
+  *
+  * By default, this trait creates a new `Application` for the `Suite` according to the components defined in the test, this
+  * is made available via the `app` field defined in this trait and a new `TestServer` for the `Suite` using the port number provided by
+  * its `port` field and the `Application` provided by its `app` field. If your `Suite` needs a different port number,
+  * override `port`.
+  *
+  * This `TestSuiteMixin` trait's overridden `run` method calls `start` on the `TestServer`
+  * before executing the `Suite` via a call to `super.run`.
+  * In addition, it places a reference to the `Application` provided by `app` into the `ConfigMap`
+  * under the key `org.scalatestplus.play.app` and to the port number provided by `port` under the key
+  * `org.scalatestplus.play.port`.  This allows any nested `Suite`s to access the `Suite`'s
+  * `Application` and port number as well, most easily by having the nested `Suite`s mix in the
+  * [[org.scalatestplus.play.ConfiguredServer ConfiguredServer]] trait. On the status returned by `super.run`, this
+  * trait's overridden `run` method registers a call to `stop` on the `TestServer` to be executed when the `Status`
+  * completes, and returns the same `Status`. This ensure the `TestServer` will continue to execute until
+  * all nested suites have completed, after which the `TestServer` will be stopped.
+  *
+  * Here's an example that demonstrates some of the services provided by this trait:
+  *
+  * <pre class="stHighlight">
+  * import org.scalatestplus.play.PlaySpec
+  * import OneServerPerSuiteWithComponents
+  * import play.api._
+  * import play.api.mvc.Result
+  * import play.api.test.Helpers._
+  * import play.api.test.{FakeRequest, Helpers}
+  *
+  * import scala.concurrent.Future
+  *
+  * class ExampleComponentsSpec extends PlaySpec with OneServerPerSuiteWithComponents {
+  *
+  *   override def components: BuiltInComponents = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
+  *
+  *     import play.api.mvc.Results
+  *     import play.api.routing.Router
+  *     import play.api.routing.sird._
+  *
+  *     lazy val router: Router = Router.from({
+  *       case GET(p"/") => defaultActionBuilder {
+  *         Results.Ok("success!")
+  *       }
+  *     })
+  *
+  *     override lazy val configuration: Configuration = context.initialConfiguration ++ Configuration("foo" -> "bar", "ehcacheplugin" -> "disabled")
+  *   }
+  *
+  *   "The OneServerPerSuiteWithComponents trait" must {
+  *     "provide an Application" in {
+  *       import play.api.test.Helpers.{GET, route}
+  *       val Some(result: Future[Result]) = route(app, FakeRequest(GET, "/"))
+  *       Helpers.contentAsString(result) must be("success!")
+  *     }
+  *     "override the configuration" in {
+  *       app.configuration.getOptional[String]("foo") mustBe Some("bar")
+  *     }
+  *   }
+  * }
+  * </pre>
+  *
+  * If you have many tests that can share the same `Application` and `TestServer`, and you don't want to put them all into one
+  * test class, you can place them into different `Suite` classes.
+  * These will be your nested suites. Create a master suite that extends `OneServerPerSuite` and declares the nested
+  * `Suite`s. Annotate the nested suites with `@DoNotDiscover` and have them extend `ConfiguredServer`. Here's an example:
+  *
+  * <pre class="stHighlight">
+  * import org.scalatest.{ DoNotDiscover, Suites, TestSuite }
+  * import org.scalatestplus.play.components._
+  * import org.scalatestplus.play.{ ConfiguredServer, PlaySpec }
+  * import play.api._
+  * import play.api.mvc.Result
+  * import play.api.test.Helpers._
+  * import play.api.test.{ FakeRequest, Helpers }
+  *
+  * import scala.concurrent.Future
+  *
+  * class NestedExampleSpec extends Suites(
+  *   new OneSpec,
+  *   new TwoSpec,
+  *   new RedSpec,
+  *   new BlueSpec
+  * ) with OneServerPerSuiteWithComponents with TestSuite {
+  *   // Override fakeApplication if you need an Application with other than non-default parameters.
+  *   override def components: BuiltInComponents = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
+  *
+  *     import play.api.mvc.Results
+  *     import play.api.routing.Router
+  *     import play.api.routing.sird._
+  *
+  *     lazy val router: Router = Router.from({
+  *       case GET(p"/") => defaultActionBuilder {
+  *         Results.Ok("success!")
+  *       }
+  *     })
+  *
+  *     override lazy val configuration: Configuration = context.initialConfiguration ++ Configuration("ehcacheplugin" -> "disabled")
+  *
+  *   }
+  * }
+  *
+  * // These are the nested suites
+  *
+  * @DoNotDiscover class OneSpec extends PlaySpec with ConfiguredServer {
+  *   "OneSpec" must {
+  *     "make the Application available implicitly" in {
+  *       def getConfig(key: String)(implicit app: Application) = app.configuration.getOptional[String](key)
+  *
+  *       getConfig("ehcacheplugin") mustBe Some("disabled")
+  *     }
+  *   }
+  *
+  * }
+  * @DoNotDiscover class TwoSpec extends PlaySpec with ConfiguredServer
+  * @DoNotDiscover class RedSpec extends PlaySpec with ConfiguredServer
+  * @DoNotDiscover class BlueSpec extends PlaySpec with ConfiguredServer {
+  *
+  *   "The NestedExampleSpeccc" must {
+  *     "provide an Application" in {
+  *       import play.api.test.Helpers.{ GET, route }
+  *       val Some(result: Future[Result]) = route(app, FakeRequest(GET, "/"))
+  *       Helpers.contentAsString(result) must be("success!")
+  *     }
+  *     "provide an actual running server" in {
+  *       import java.net._
+  *       val url = new URL("http://localhost:" + port + "/boum")
+  *       val con = url.openConnection().asInstanceOf[HttpURLConnection]
+  *       try con.getResponseCode mustBe 404
+  *       finally con.disconnect()
+  *     }
+  *   }
+  * }
+  * </pre>
+  */
 trait OneServerPerSuiteWithComponents
     extends BaseOneServerPerSuite
     with WithApplicationComponents

--- a/it/org/scalatestplus/play/components/OneServerPerTestWithComponents.scala
+++ b/it/org/scalatestplus/play/components/OneServerPerTestWithComponents.scala
@@ -1,63 +1,63 @@
 package org.scalatestplus.play.components
 
 import org.scalatest.TestSuite
-import org.scalatestplus.play.{ BaseOneServerPerTest, FakeApplicationFactory }
+import org.scalatestplus.play.{BaseOneServerPerTest, FakeApplicationFactory}
 import play.api.Application
 
 /**
- * An extension of [[BaseOneServerPerTest]] providing Compile-time DI.
- *
- * Trait that provides a new `Application` and running `TestServer` instance for each test executed in a ScalaTest `Suite`
- *
- * This `TestSuiteMixin` trait overrides ScalaTest's `withFixture` method to create a new `Application` and `TestServer`
- * before each test, and ensure they are cleaned up after the test has completed. The `Application` is available (implicitly) from
- * method `app`. The `TestServer`'s port number is available as `port` (and implicitly available as `portNumber`, wrapped
- * in a [[org.scalatestplus.play.PortNumber PortNumber]]).
- *
- * By default, this trait creates a new `Application` for each test according to the components defined in the test.
- *
- * Here's an example that demonstrates some of the services provided by this trait:
- *
- * <pre class="stHighlight">
- * import org.scalatestplus.play.PlaySpec
- * import OneServerPerTestWithComponents
- * import play.api._
- * import play.api.mvc.Result
- * import play.api.test.Helpers._
- * import play.api.test.{FakeRequest, Helpers}
- *
- * import scala.concurrent.Future
- *
- * class ExampleComponentsSpec extends PlaySpec with OneServerPerTestWithComponents {
- *
- *   override def components: BuiltInComponents = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
- *
- *     import play.api.mvc.Results
- *     import play.api.routing.Router
- *     import play.api.routing.sird._
- *
- *     lazy val router: Router = Router.from({
- *       case GET(p"/") => defaultActionBuilder {
- *         Results.Ok("success!")
- *       }
- *     })
- *
- *     override lazy val configuration: Configuration = context.initialConfiguration ++ Configuration("foo" -> "bar", "ehcacheplugin" -> "disabled")
- *   }
- *
- *   "The OneServerPerTestWithComponents trait" must {
- *     "provide an Application" in {
- *       import play.api.test.Helpers.{GET, route}
- *       val Some(result: Future[Result]) = route(app, FakeRequest(GET, "/"))
- *       Helpers.contentAsString(result) must be("success!")
- *     }
- *     "override the configuration" in {
- *       app.configuration.getOptional[String]("foo") mustBe Some("bar")
- *     }
- *   }
- * }
- * </pre>
- */
+  * An extension of [[BaseOneServerPerTest]] providing Compile-time DI.
+  *
+  * Trait that provides a new `Application` and running `TestServer` instance for each test executed in a ScalaTest `Suite`
+  *
+  * This `TestSuiteMixin` trait overrides ScalaTest's `withFixture` method to create a new `Application` and `TestServer`
+  * before each test, and ensure they are cleaned up after the test has completed. The `Application` is available (implicitly) from
+  * method `app`. The `TestServer`'s port number is available as `port` (and implicitly available as `portNumber`, wrapped
+  * in a [[org.scalatestplus.play.PortNumber PortNumber]]).
+  *
+  * By default, this trait creates a new `Application` for each test according to the components defined in the test.
+  *
+  * Here's an example that demonstrates some of the services provided by this trait:
+  *
+  * <pre class="stHighlight">
+  * import org.scalatestplus.play.PlaySpec
+  * import OneServerPerTestWithComponents
+  * import play.api._
+  * import play.api.mvc.Result
+  * import play.api.test.Helpers._
+  * import play.api.test.{FakeRequest, Helpers}
+  *
+  * import scala.concurrent.Future
+  *
+  * class ExampleComponentsSpec extends PlaySpec with OneServerPerTestWithComponents {
+  *
+  *   override def components: BuiltInComponents = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
+  *
+  *     import play.api.mvc.Results
+  *     import play.api.routing.Router
+  *     import play.api.routing.sird._
+  *
+  *     lazy val router: Router = Router.from({
+  *       case GET(p"/") => defaultActionBuilder {
+  *         Results.Ok("success!")
+  *       }
+  *     })
+  *
+  *     override lazy val configuration: Configuration = context.initialConfiguration ++ Configuration("foo" -> "bar", "ehcacheplugin" -> "disabled")
+  *   }
+  *
+  *   "The OneServerPerTestWithComponents trait" must {
+  *     "provide an Application" in {
+  *       import play.api.test.Helpers.{GET, route}
+  *       val Some(result: Future[Result]) = route(app, FakeRequest(GET, "/"))
+  *       Helpers.contentAsString(result) must be("success!")
+  *     }
+  *     "override the configuration" in {
+  *       app.configuration.getOptional[String]("foo") mustBe Some("bar")
+  *     }
+  *   }
+  * }
+  * </pre>
+  */
 trait OneServerPerTestWithComponents
     extends BaseOneServerPerTest
     with WithApplicationComponents

--- a/it/org/scalatestplus/play/components/WithApplicationComponents.scala
+++ b/it/org/scalatestplus/play/components/WithApplicationComponents.scala
@@ -1,36 +1,36 @@
 package org.scalatestplus.play.components
 
-import play.api.{ BuiltInComponents, _ }
+import play.api.{BuiltInComponents, _}
 
 /**
- * A trait that provides a components in scope and returns them when newApplication is called.
- *
- * Mixin one of the public traits in this package to provide the desired functionality.
- *
- * This class has several methods that can be used to customize the behavior in specific ways.
- *
- * This is targeted at functional tests requiring a running application that is bootstrapped using Macwire/Compile time DI.
- * This is provided as an alternative to the [[play.api.inject.guice.GuiceApplicationBuilder]] which requires guice bootstrapping.
- *
- * @see https://www.playframework.com/documentation/2.5.x/ScalaFunctionalTestingWithScalaTest#Creating-Application-instances-for-testing
- */
+  * A trait that provides a components in scope and returns them when newApplication is called.
+  *
+  * Mixin one of the public traits in this package to provide the desired functionality.
+  *
+  * This class has several methods that can be used to customize the behavior in specific ways.
+  *
+  * This is targeted at functional tests requiring a running application that is bootstrapped using Macwire/Compile time DI.
+  * This is provided as an alternative to the [[play.api.inject.guice.GuiceApplicationBuilder]] which requires guice bootstrapping.
+  *
+  * @see https://www.playframework.com/documentation/2.5.x/ScalaFunctionalTestingWithScalaTest#Creating-Application-instances-for-testing
+  */
 trait WithApplicationComponents {
 
   /**
-   * Override this function to instantiate the components - a factory of sorts.
-   *
-   * @return the components to be used by the application
-   */
+    * Override this function to instantiate the components - a factory of sorts.
+    *
+    * @return the components to be used by the application
+    */
   def components: BuiltInComponents
 
   /**
-   * @return new application instance and set the components. This must be called for components to be properly set up.
-   */
+    * @return new application instance and set the components. This must be called for components to be properly set up.
+    */
   final def newApplication: Application = components.application
 
   /**
-   * @return a context to use to create the application.
-   */
+    * @return a context to use to create the application.
+    */
   lazy val context: ApplicationLoader.Context = {
     val env = Environment.simple()
     ApplicationLoader.createContext(env)

--- a/it/uk/gov/hmrc/mobilehelptosave/AccountConfigISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/AccountConfigISpec.scala
@@ -30,8 +30,17 @@ import uk.gov.hmrc.mobilehelptosave.support.{ComponentSupport, JsonMatchers, Wir
   * Tests that the Get Account endpoint uses configuration values correctly
   * (e.g. changes its response when configuration is changed).
   */
-class AccountConfigISpec extends WordSpec with Matchers with JsonMatchers with FutureAwaits with DefaultAwaitTimeout
-  with WsScalaTestClient with WireMockSupport with WithTestServer with ComponentSupport with WithApplicationComponents {
+class AccountConfigISpec
+    extends WordSpec
+    with Matchers
+    with JsonMatchers
+    with FutureAwaits
+    with DefaultAwaitTimeout
+    with WsScalaTestClient
+    with WireMockSupport
+    with WithTestServer
+    with ComponentSupport
+    with WithApplicationComponents {
 
   private val generator = new Generator(0)
   private val nino      = generator.nextNino
@@ -48,14 +57,14 @@ class AccountConfigISpec extends WordSpec with Matchers with JsonMatchers with F
           .configure(
             "helpToSave.inAppPaymentsEnabled" -> "false"
           )
-          .build()) {
+          .build()) { (app: Application, portNumber: PortNumber) =>
+        implicit val implicitPortNumber: PortNumber = portNumber
+        implicit val wsClient:           WSClient   = components.wsClient
 
-        (app: Application, portNumber: PortNumber) =>
-          implicit val implicitPortNumber: PortNumber = portNumber
-          implicit val wsClient: WSClient = components.wsClient
-
-          responseShouldHaveInAppPaymentsEqualTo(await(wsUrl(s"/savings-account/$nino").get()), expectedValue = false)
-          responseShouldHaveInAppPaymentsEqualTo(await(wsUrl(s"/sandbox/savings-account/$nino").get()), expectedValue = false)
+        responseShouldHaveInAppPaymentsEqualTo(await(wsUrl(s"/savings-account/$nino").get()), expectedValue = false)
+        responseShouldHaveInAppPaymentsEqualTo(
+          await(wsUrl(s"/sandbox/savings-account/$nino").get()),
+          expectedValue = false)
       }
 
       withTestServer(
@@ -65,10 +74,12 @@ class AccountConfigISpec extends WordSpec with Matchers with JsonMatchers with F
           )
           .build()) { (app: Application, portNumber: PortNumber) =>
         implicit val implicitPortNumber: PortNumber = portNumber
-        implicit val wsClient: WSClient = components.wsClient
+        implicit val wsClient:           WSClient   = components.wsClient
 
         responseShouldHaveInAppPaymentsEqualTo(await(wsUrl(s"/savings-account/$nino").get()), expectedValue = true)
-        responseShouldHaveInAppPaymentsEqualTo(await(wsUrl(s"/sandbox/savings-account/$nino").get()), expectedValue = true)
+        responseShouldHaveInAppPaymentsEqualTo(
+          await(wsUrl(s"/sandbox/savings-account/$nino").get()),
+          expectedValue = true)
       }
     }
   }

--- a/it/uk/gov/hmrc/mobilehelptosave/AccountsISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/AccountsISpec.scala
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2018 HM Revenue & Customs
  *
@@ -27,13 +26,17 @@ import uk.gov.hmrc.mobilehelptosave.scalatest.SchemaMatchers
 import uk.gov.hmrc.mobilehelptosave.stubs.{AuthStub, HelpToSaveStub}
 import uk.gov.hmrc.mobilehelptosave.support.{ComponentSupport, OneServerPerSuiteWsClient, WireMockSupport}
 
-class AccountsISpec extends WordSpec with Matchers
-  with SchemaMatchers with TransactionTestData
-  with FutureAwaits with DefaultAwaitTimeout
-  with WireMockSupport
-  with OneServerPerSuiteWsClient
-  with NumberVerification
-  with ComponentSupport {
+class AccountsISpec
+    extends WordSpec
+    with Matchers
+    with SchemaMatchers
+    with TransactionTestData
+    with FutureAwaits
+    with DefaultAwaitTimeout
+    with WireMockSupport
+    with OneServerPerSuiteWsClient
+    with NumberVerification
+    with ComponentSupport {
 
   override implicit lazy val app: Application = appBuilder.build()
 
@@ -52,32 +55,32 @@ class AccountsISpec extends WordSpec with Matchers
 
       response.status shouldBe 200
 
-      (response.json \ "number").as[String] shouldBe "1000000000001"
-      (response.json \ "openedYearMonth").as[String] shouldBe "2018-01"
-      (response.json \ "isClosed").as[Boolean] shouldBe false
+      (response.json \ "number").as[String]                   shouldBe "1000000000001"
+      (response.json \ "openedYearMonth").as[String]          shouldBe "2018-01"
+      (response.json \ "isClosed").as[Boolean]                shouldBe false
       (response.json \ "blocked" \ "unspecified").as[Boolean] shouldBe false
       shouldBeBigDecimal(response.json \ "balance", BigDecimal("123.45"))
       shouldBeBigDecimal(response.json \ "paidInThisMonth", BigDecimal("27.88"))
       shouldBeBigDecimal(response.json \ "canPayInThisMonth", BigDecimal("22.12"))
       shouldBeBigDecimal(response.json \ "maximumPaidInThisMonth", BigDecimal(50))
-      (response.json \ "thisMonthEndDate").as[String] shouldBe "2018-04-30"
+      (response.json \ "thisMonthEndDate").as[String]          shouldBe "2018-04-30"
       (response.json \ "nextPaymentMonthStartDate").as[String] shouldBe "2018-05-01"
 
-      (response.json \ "accountHolderName").as[String] shouldBe "Testfore Testsur"
+      (response.json \ "accountHolderName").as[String]  shouldBe "Testfore Testsur"
       (response.json \ "accountHolderEmail").as[String] shouldBe "testemail@example.com"
 
-      val firstBonusTermJson = (response.json \ "bonusTerms") (0)
+      val firstBonusTermJson = (response.json \ "bonusTerms")(0)
       shouldBeBigDecimal(firstBonusTermJson \ "bonusEstimate", BigDecimal("90.99"))
       shouldBeBigDecimal(firstBonusTermJson \ "bonusPaid", BigDecimal("90.99"))
-      (firstBonusTermJson \ "endDate").as[String] shouldBe "2019-12-31"
-      (firstBonusTermJson \ "bonusPaidOnOrAfterDate").as[String] shouldBe "2020-01-01"
+      (firstBonusTermJson \ "endDate").as[String]                           shouldBe "2019-12-31"
+      (firstBonusTermJson \ "bonusPaidOnOrAfterDate").as[String]            shouldBe "2020-01-01"
       (firstBonusTermJson \ "balanceMustBeMoreThanForBonus").as[BigDecimal] shouldBe 0
 
-      val secondBonusTermJson = (response.json \ "bonusTerms") (1)
+      val secondBonusTermJson = (response.json \ "bonusTerms")(1)
       shouldBeBigDecimal(secondBonusTermJson \ "bonusEstimate", BigDecimal(12))
       shouldBeBigDecimal(secondBonusTermJson \ "bonusPaid", BigDecimal(0))
-      (secondBonusTermJson \ "endDate").as[String] shouldBe "2021-12-31"
-      (secondBonusTermJson \ "bonusPaidOnOrAfterDate").as[String] shouldBe "2022-01-01"
+      (secondBonusTermJson \ "endDate").as[String]                           shouldBe "2021-12-31"
+      (secondBonusTermJson \ "bonusPaidOnOrAfterDate").as[String]            shouldBe "2022-01-01"
       (secondBonusTermJson \ "balanceMustBeMoreThanForBonus").as[BigDecimal] shouldBe BigDecimal("181.98")
 
       (response.json \ "currentBonusTerm").as[String] shouldBe "First"
@@ -92,32 +95,32 @@ class AccountsISpec extends WordSpec with Matchers
 
       response.status shouldBe 200
 
-      (response.json \ "number").as[String] shouldBe "1000000000001"
-      (response.json \ "openedYearMonth").as[String] shouldBe "2018-01"
-      (response.json \ "isClosed").as[Boolean] shouldBe false
+      (response.json \ "number").as[String]                   shouldBe "1000000000001"
+      (response.json \ "openedYearMonth").as[String]          shouldBe "2018-01"
+      (response.json \ "isClosed").as[Boolean]                shouldBe false
       (response.json \ "blocked" \ "unspecified").as[Boolean] shouldBe false
       shouldBeBigDecimal(response.json \ "balance", BigDecimal("123.45"))
       shouldBeBigDecimal(response.json \ "paidInThisMonth", BigDecimal("27.88"))
       shouldBeBigDecimal(response.json \ "canPayInThisMonth", BigDecimal("22.12"))
       shouldBeBigDecimal(response.json \ "maximumPaidInThisMonth", BigDecimal(50))
-      (response.json \ "thisMonthEndDate").as[String] shouldBe "2018-04-30"
+      (response.json \ "thisMonthEndDate").as[String]          shouldBe "2018-04-30"
       (response.json \ "nextPaymentMonthStartDate").as[String] shouldBe "2018-05-01"
 
       (response.json \ "accountHolderName").as[String] shouldBe "Testfore Testsur"
-      response.json.as[JsObject].keys should not contain "accountHolderEmail"
+      response.json.as[JsObject].keys                  should not contain "accountHolderEmail"
 
-      val firstBonusTermJson = (response.json \ "bonusTerms") (0)
+      val firstBonusTermJson = (response.json \ "bonusTerms")(0)
       shouldBeBigDecimal(firstBonusTermJson \ "bonusEstimate", BigDecimal("90.99"))
       shouldBeBigDecimal(firstBonusTermJson \ "bonusPaid", BigDecimal("90.99"))
-      (firstBonusTermJson \ "endDate").as[String] shouldBe "2019-12-31"
-      (firstBonusTermJson \ "bonusPaidOnOrAfterDate").as[String] shouldBe "2020-01-01"
+      (firstBonusTermJson \ "endDate").as[String]                           shouldBe "2019-12-31"
+      (firstBonusTermJson \ "bonusPaidOnOrAfterDate").as[String]            shouldBe "2020-01-01"
       (firstBonusTermJson \ "balanceMustBeMoreThanForBonus").as[BigDecimal] shouldBe 0
 
-      val secondBonusTermJson = (response.json \ "bonusTerms") (1)
+      val secondBonusTermJson = (response.json \ "bonusTerms")(1)
       shouldBeBigDecimal(secondBonusTermJson \ "bonusEstimate", BigDecimal(12))
       shouldBeBigDecimal(secondBonusTermJson \ "bonusPaid", BigDecimal(0))
-      (secondBonusTermJson \ "endDate").as[String] shouldBe "2021-12-31"
-      (secondBonusTermJson \ "bonusPaidOnOrAfterDate").as[String] shouldBe "2022-01-01"
+      (secondBonusTermJson \ "endDate").as[String]                           shouldBe "2021-12-31"
+      (secondBonusTermJson \ "bonusPaidOnOrAfterDate").as[String]            shouldBe "2022-01-01"
       (secondBonusTermJson \ "balanceMustBeMoreThanForBonus").as[BigDecimal] shouldBe BigDecimal("181.98")
 
       (response.json \ "currentBonusTerm").as[String] shouldBe "First"
@@ -131,7 +134,7 @@ class AccountsISpec extends WordSpec with Matchers
 
       response.status shouldBe 404
 
-      (response.json \ "code").as[String] shouldBe "ACCOUNT_NOT_FOUND"
+      (response.json \ "code").as[String]    shouldBe "ACCOUNT_NOT_FOUND"
       (response.json \ "message").as[String] shouldBe "No Help to Save account exists for the specified NINO"
 
       HelpToSaveStub.accountShouldNotHaveBeenCalled(nino)
@@ -181,10 +184,10 @@ class AccountsISpec extends WordSpec with Matchers
       val response: WSResponse = await(wsUrl(s"/savings-account/$nino").get())
       response.status shouldBe 200
 
-      (response.json \ "number").as[String] shouldBe "1000000000002"
+      (response.json \ "number").as[String]          shouldBe "1000000000002"
       (response.json \ "openedYearMonth").as[String] shouldBe "2018-03"
 
-      (response.json \ "isClosed").as[Boolean] shouldBe true
+      (response.json \ "isClosed").as[Boolean]   shouldBe true
       (response.json \ "closureDate").as[String] shouldBe "2018-04-09"
       shouldBeBigDecimal(response.json \ "closingBalance", BigDecimal(10))
 
@@ -193,21 +196,21 @@ class AccountsISpec extends WordSpec with Matchers
       shouldBeBigDecimal(response.json \ "paidInThisMonth", BigDecimal(0))
       shouldBeBigDecimal(response.json \ "canPayInThisMonth", BigDecimal(50))
       shouldBeBigDecimal(response.json \ "maximumPaidInThisMonth", BigDecimal(50))
-      (response.json \ "thisMonthEndDate").as[String] shouldBe "2018-04-30"
+      (response.json \ "thisMonthEndDate").as[String]          shouldBe "2018-04-30"
       (response.json \ "nextPaymentMonthStartDate").as[String] shouldBe "2018-05-01"
 
-      val firstBonusTermJson = (response.json \ "bonusTerms") (0)
+      val firstBonusTermJson = (response.json \ "bonusTerms")(0)
       shouldBeBigDecimal(firstBonusTermJson \ "bonusEstimate", BigDecimal("7.50"))
       shouldBeBigDecimal(firstBonusTermJson \ "bonusPaid", BigDecimal(0))
-      (firstBonusTermJson \ "endDate").as[String] shouldBe "2020-02-29"
-      (firstBonusTermJson \ "bonusPaidOnOrAfterDate").as[String] shouldBe "2020-03-01"
+      (firstBonusTermJson \ "endDate").as[String]                           shouldBe "2020-02-29"
+      (firstBonusTermJson \ "bonusPaidOnOrAfterDate").as[String]            shouldBe "2020-03-01"
       (firstBonusTermJson \ "balanceMustBeMoreThanForBonus").as[BigDecimal] shouldBe 0
 
-      val secondBonusTermJson = (response.json \ "bonusTerms") (1)
+      val secondBonusTermJson = (response.json \ "bonusTerms")(1)
       shouldBeBigDecimal(secondBonusTermJson \ "bonusEstimate", BigDecimal(0))
       shouldBeBigDecimal(secondBonusTermJson \ "bonusPaid", BigDecimal(0))
-      (secondBonusTermJson \ "endDate").as[String] shouldBe "2022-02-28"
-      (secondBonusTermJson \ "bonusPaidOnOrAfterDate").as[String] shouldBe "2022-03-01"
+      (secondBonusTermJson \ "endDate").as[String]                           shouldBe "2022-02-28"
+      (secondBonusTermJson \ "bonusPaidOnOrAfterDate").as[String]            shouldBe "2022-03-01"
       (secondBonusTermJson \ "balanceMustBeMoreThanForBonus").as[BigDecimal] shouldBe BigDecimal("15.00")
 
       (response.json \ "currentBonusTerm").as[String] shouldBe "First"
@@ -221,11 +224,11 @@ class AccountsISpec extends WordSpec with Matchers
       val response: WSResponse = await(wsUrl(s"/savings-account/$nino").get())
       response.status shouldBe 200
 
-      (response.json \ "number").as[String] shouldBe "1100000112068"
+      (response.json \ "number").as[String]          shouldBe "1100000112068"
       (response.json \ "openedYearMonth").as[String] shouldBe "2017-11"
 
-      (response.json \ "isClosed").as[Boolean] shouldBe false
-      (response.json \ "closureDate").asOpt[String] shouldBe None
+      (response.json \ "isClosed").as[Boolean]         shouldBe false
+      (response.json \ "closureDate").asOpt[String]    shouldBe None
       (response.json \ "closingBalance").asOpt[String] shouldBe None
 
       (response.json \ "blocked" \ "unspecified").as[Boolean] shouldBe true
@@ -233,21 +236,21 @@ class AccountsISpec extends WordSpec with Matchers
       shouldBeBigDecimal(response.json \ "paidInThisMonth", BigDecimal(50))
       shouldBeBigDecimal(response.json \ "canPayInThisMonth", BigDecimal(0))
       shouldBeBigDecimal(response.json \ "maximumPaidInThisMonth", BigDecimal(50))
-      (response.json \ "thisMonthEndDate").as[String] shouldBe "2018-03-31"
+      (response.json \ "thisMonthEndDate").as[String]          shouldBe "2018-03-31"
       (response.json \ "nextPaymentMonthStartDate").as[String] shouldBe "2018-04-01"
 
-      val firstBonusTermJson = (response.json \ "bonusTerms") (0)
+      val firstBonusTermJson = (response.json \ "bonusTerms")(0)
       shouldBeBigDecimal(firstBonusTermJson \ "bonusEstimate", BigDecimal(125))
       shouldBeBigDecimal(firstBonusTermJson \ "bonusPaid", BigDecimal(0))
-      (firstBonusTermJson \ "endDate").as[String] shouldBe "2019-10-31"
-      (firstBonusTermJson \ "bonusPaidOnOrAfterDate").as[String] shouldBe "2019-11-01"
+      (firstBonusTermJson \ "endDate").as[String]                           shouldBe "2019-10-31"
+      (firstBonusTermJson \ "bonusPaidOnOrAfterDate").as[String]            shouldBe "2019-11-01"
       (firstBonusTermJson \ "balanceMustBeMoreThanForBonus").as[BigDecimal] shouldBe 0
 
-      val secondBonusTermJson = (response.json \ "bonusTerms") (1)
+      val secondBonusTermJson = (response.json \ "bonusTerms")(1)
       shouldBeBigDecimal(secondBonusTermJson \ "bonusEstimate", BigDecimal(0))
       shouldBeBigDecimal(secondBonusTermJson \ "bonusPaid", BigDecimal(0))
-      (secondBonusTermJson \ "endDate").as[String] shouldBe "2021-10-31"
-      (secondBonusTermJson \ "bonusPaidOnOrAfterDate").as[String] shouldBe "2021-11-01"
+      (secondBonusTermJson \ "endDate").as[String]                           shouldBe "2021-10-31"
+      (secondBonusTermJson \ "bonusPaidOnOrAfterDate").as[String]            shouldBe "2021-11-01"
       (secondBonusTermJson \ "balanceMustBeMoreThanForBonus").as[BigDecimal] shouldBe BigDecimal("250.00")
 
       (response.json \ "currentBonusTerm").as[String] shouldBe "First"
@@ -257,14 +260,14 @@ class AccountsISpec extends WordSpec with Matchers
       AuthStub.userIsNotLoggedIn()
       val response: WSResponse = await(wsUrl(s"/savings-account/$nino").get())
       response.status shouldBe 401
-      response.body shouldBe "Authorisation failure [Bearer token not supplied]"
+      response.body   shouldBe "Authorisation failure [Bearer token not supplied]"
     }
 
     "return 403 Forbidden when the user is logged in with an insufficient confidence level" in {
       AuthStub.userIsLoggedInWithInsufficientConfidenceLevel()
       val response: WSResponse = await(wsUrl(s"/savings-account/$nino").get())
       response.status shouldBe 403
-      response.body shouldBe "Authorisation failure [Insufficient ConfidenceLevel]"
+      response.body   shouldBe "Authorisation failure [Insufficient ConfidenceLevel]"
     }
   }
 }

--- a/it/uk/gov/hmrc/mobilehelptosave/HealthISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/HealthISpec.scala
@@ -8,9 +8,12 @@ import uk.gov.hmrc.mobilehelptosave.support.OneServerPerSuiteWsClient
 /**
   * Check the health endpoints to ensure that they're wired correctly
   */
-class HealthISpec extends WordSpec with Matchers
-  with FutureAwaits with DefaultAwaitTimeout
-  with OneServerPerSuiteWsClient {
+class HealthISpec
+    extends WordSpec
+    with Matchers
+    with FutureAwaits
+    with DefaultAwaitTimeout
+    with OneServerPerSuiteWsClient {
 
   "GET /ping/ping" should {
     "return a 200 Ok response" in (await(wsUrl("/ping/ping").get()).status shouldBe 200)
@@ -18,8 +21,7 @@ class HealthISpec extends WordSpec with Matchers
 
   "GET /admin/details" should {
     val url = wsUrl("/admin/details")
-    "return a 200 Ok response" in (await(url.get()).status shouldBe 200)
+    "return a 200 Ok response" in (await(url.get()).status         shouldBe 200)
     "return an empty object" in (Json.parse(await(url.get()).body) shouldBe JsObject(Seq()))
   }
-
 }

--- a/it/uk/gov/hmrc/mobilehelptosave/SandboxISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/SandboxISpec.scala
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2018 HM Revenue & Customs
  *
@@ -28,11 +27,15 @@ import uk.gov.hmrc.mobilehelptosave.repository.SavingsGoalEvent
 import uk.gov.hmrc.mobilehelptosave.scalatest.SchemaMatchers
 import uk.gov.hmrc.mobilehelptosave.support.{OneServerPerSuiteWsClient, WireMockSupport}
 
-class SandboxISpec extends WordSpec with Matchers
-  with SchemaMatchers with TransactionTestData
-  with FutureAwaits with DefaultAwaitTimeout
-  with WireMockSupport
-  with OneServerPerSuiteWsClient {
+class SandboxISpec
+    extends WordSpec
+    with Matchers
+    with SchemaMatchers
+    with TransactionTestData
+    with FutureAwaits
+    with DefaultAwaitTimeout
+    with WireMockSupport
+    with OneServerPerSuiteWsClient {
 
   private val sandboxRoutingHeader = "X-MOBILE-USER-ID" -> "208606423740"
   private val generator            = new Generator(0)
@@ -40,8 +43,9 @@ class SandboxISpec extends WordSpec with Matchers
 
   "GET /savings-account/{nino}/transactions with sandbox header" should {
     "Return OK response containing valid Transactions JSON" in {
-      val response: WSResponse = await(wsUrl(s"/savings-account/$nino/transactions").withHeaders(sandboxRoutingHeader).get())
-      response.status shouldBe Status.OK
+      val response: WSResponse =
+        await(wsUrl(s"/savings-account/$nino/transactions").withHeaders(sandboxRoutingHeader).get())
+      response.status                      shouldBe Status.OK
       response.json.validate[Transactions] shouldBe 'success
     }
   }
@@ -49,7 +53,7 @@ class SandboxISpec extends WordSpec with Matchers
   "GET /savings-account/{nino} with sandbox header" should {
     "Return OK response containing valid Account JSON" in {
       val response: WSResponse = await(wsUrl(s"/savings-account/$nino").withHeaders(sandboxRoutingHeader).get())
-      response.status shouldBe Status.OK
+      response.status                 shouldBe Status.OK
       response.json.validate[Account] shouldBe 'success
     }
   }
@@ -57,22 +61,25 @@ class SandboxISpec extends WordSpec with Matchers
   "PUT /savings-account/:nino/goals/current-goal with sandbox header" should {
     "Return a No Content response" in {
       val goal = SavingsGoal(35.0)
-      val response: WSResponse = await(wsUrl(s"/savings-account/$nino/goals/current-goal").withHeaders(sandboxRoutingHeader).put(Json.toJson(goal)))
+      val response: WSResponse = await(
+        wsUrl(s"/savings-account/$nino/goals/current-goal").withHeaders(sandboxRoutingHeader).put(Json.toJson(goal)))
       response.status shouldBe Status.NO_CONTENT
     }
   }
 
   "DELETE /savings-account/:nino/goals/current-goal with sandbox header" should {
     "Return a No Content response" in {
-      val response: WSResponse = await(wsUrl(s"/savings-account/$nino/goals/current-goal").withHeaders(sandboxRoutingHeader).delete())
+      val response: WSResponse =
+        await(wsUrl(s"/savings-account/$nino/goals/current-goal").withHeaders(sandboxRoutingHeader).delete())
       response.status shouldBe Status.NO_CONTENT
     }
   }
 
   "GET /savings-account/{nino}/goals/events with sandbox header" should {
     "Return OK response containing events JSON" in {
-      val response: WSResponse = await(wsUrl(s"/savings-account/$nino/goals/events").withHeaders(sandboxRoutingHeader).get())
-      response.status shouldBe Status.OK
+      val response: WSResponse =
+        await(wsUrl(s"/savings-account/$nino/goals/events").withHeaders(sandboxRoutingHeader).get())
+      response.status                                shouldBe Status.OK
       response.json.validate[List[SavingsGoalEvent]] shouldBe 'success
     }
   }

--- a/it/uk/gov/hmrc/mobilehelptosave/SavingsGoalEventsISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/SavingsGoalEventsISpec.scala
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2018 HM Revenue & Customs
  *
@@ -32,7 +31,7 @@ import uk.gov.hmrc.mobilehelptosave.support.{ComponentSupport, MongoSupport, One
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class SavingsGoalEventsISpec
-  extends WordSpec
+    extends WordSpec
     with Matchers
     with SchemaMatchers
     with TransactionTestData

--- a/it/uk/gov/hmrc/mobilehelptosave/SavingsGoalsISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/SavingsGoalsISpec.scala
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2018 HM Revenue & Customs
  *
@@ -33,7 +32,7 @@ import uk.gov.hmrc.mobilehelptosave.support.{ComponentSupport, MongoSupport, One
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class SavingsGoalsISpec
-  extends WordSpec
+    extends WordSpec
     with Matchers
     with SchemaMatchers
     with TransactionTestData
@@ -56,9 +55,8 @@ class SavingsGoalsISpec
   private val savingsGoal2   = SavingsGoal(30)
   private val validGoalJson2 = toJson(savingsGoal2)
 
-  private def setSavingsGoal(nino: Nino, json: JsValue) = {
+  private def setSavingsGoal(nino: Nino, json: JsValue) =
     await(wsUrl(s"/savings-account/${nino.toString}/goals/current-goal").put(json))
-  }
 
   trait LoggedInUserScenario {
     HelpToSaveStub.currentUserIsEnrolled()
@@ -77,29 +75,28 @@ class SavingsGoalsISpec
 
       val response: WSResponse = setSavingsGoal(nino, toJson(SavingsGoal(30.123)))
       response.status shouldBe Status.UNPROCESSABLE_ENTITY
-      response.body should include("goal amount should be a valid monetary amount")
+      response.body   should include("goal amount should be a valid monetary amount")
     }
 
     "respond with 422 when putting a value that is not a valid savings goal" in new LoggedInUserScenario {
 
       val response: WSResponse = setSavingsGoal(nino, toJson(SavingsGoal(0.10)))
       response.status shouldBe Status.UNPROCESSABLE_ENTITY
-      response.body should include("goal amount should be a valid monetary amount")
+      response.body   should include("goal amount should be a valid monetary amount")
     }
-
 
     "respond with 422 when putting a value that is greater than the monthly savings goal" in new LoggedInUserScenario {
 
       val response: WSResponse = setSavingsGoal(nino, toJson(SavingsGoal(51)))
       response.status shouldBe Status.UNPROCESSABLE_ENTITY
-      response.body should include("goal amount should be in range 1 to 50")
+      response.body   should include("goal amount should be in range 1 to 50")
     }
 
     "set the goal" in new LoggedInUserScenario {
 
       val response: WSResponse = await {
         for {
-          _ <- wsUrl(s"/savings-account/$nino/goals/current-goal").put(validGoalJson)
+          _    <- wsUrl(s"/savings-account/$nino/goals/current-goal").put(validGoalJson)
           resp <- wsUrl(s"/savings-account/$nino").get()
         } yield resp
       }
@@ -113,8 +110,8 @@ class SavingsGoalsISpec
 
       val response: WSResponse = await {
         for {
-          _ <- wsUrl(s"/savings-account/$nino/goals/current-goal").put(validGoalJson)
-          _ <- wsUrl(s"/savings-account/$nino/goals/current-goal").put(validGoalJson2)
+          _    <- wsUrl(s"/savings-account/$nino/goals/current-goal").put(validGoalJson)
+          _    <- wsUrl(s"/savings-account/$nino/goals/current-goal").put(validGoalJson2)
           resp <- wsUrl(s"/savings-account/$nino").get()
         } yield resp
       }
@@ -130,7 +127,7 @@ class SavingsGoalsISpec
 
       val response: WSResponse = setSavingsGoal(nino, validGoalJson)
 
-      (response.json \ "code").as[String] shouldBe "ACCOUNT_NOT_FOUND"
+      (response.json \ "code").as[String]    shouldBe "ACCOUNT_NOT_FOUND"
       (response.json \ "message").as[String] shouldBe "No Help to Save account exists for the specified NINO"
 
       response.status shouldBe 404
@@ -140,17 +137,16 @@ class SavingsGoalsISpec
       AuthStub.userIsNotLoggedIn()
       val response: WSResponse = setSavingsGoal(nino, validGoalJson)
       response.status shouldBe 401
-      response.body shouldBe "Authorisation failure [Bearer token not supplied]"
+      response.body   shouldBe "Authorisation failure [Bearer token not supplied]"
     }
 
     "return 403 Forbidden when the user is logged in with an insufficient confidence level" in {
       AuthStub.userIsLoggedInWithInsufficientConfidenceLevel()
       val response: WSResponse = setSavingsGoal(nino, validGoalJson)
       response.status shouldBe 403
-      response.body shouldBe "Authorisation failure [Insufficient ConfidenceLevel]"
+      response.body   shouldBe "Authorisation failure [Insufficient ConfidenceLevel]"
     }
   }
-
 
   "DELETE /savings-account/{nino}/goals/current-goal" should {
     "Respond with NoContent" in new LoggedInUserScenario {
@@ -163,8 +159,8 @@ class SavingsGoalsISpec
 
       val response: WSResponse = await {
         for {
-          _ <- wsUrl(s"/savings-account/$nino/goals/current-goal").put(validGoalJson)
-          _ <- wsUrl(s"/savings-account/$nino/goals/current-goal").delete()
+          _    <- wsUrl(s"/savings-account/$nino/goals/current-goal").put(validGoalJson)
+          _    <- wsUrl(s"/savings-account/$nino/goals/current-goal").delete()
           resp <- wsUrl(s"/savings-account/$nino").get()
         } yield resp
       }

--- a/it/uk/gov/hmrc/mobilehelptosave/StartupConfigISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/StartupConfigISpec.scala
@@ -33,11 +33,20 @@ import uk.gov.hmrc.mobilehelptosave.support.{ComponentSupport, JsonMatchers, Wir
   * Tests that the startup endpoint uses configuration values correctly
   * (e.g. changes its response when configuration is changed).
   */
-class StartupConfigISpec extends WordSpec with Matchers with JsonMatchers with FutureAwaits with DefaultAwaitTimeout
-  with WsScalaTestClient with WireMockSupport with WithTestServer with ComponentSupport with WithApplicationComponents {
+class StartupConfigISpec
+    extends WordSpec
+    with Matchers
+    with JsonMatchers
+    with FutureAwaits
+    with DefaultAwaitTimeout
+    with WsScalaTestClient
+    with WireMockSupport
+    with WithTestServer
+    with ComponentSupport
+    with WithApplicationComponents {
 
-  private val generator = new Generator(0)
-  private val nino = generator.nextNino
+  private val generator     = new Generator(0)
+  private val nino          = generator.nextNino
   private val base64Encoder = Base64.getEncoder
 
   "GET /mobile-help-to-save/startup" should {
@@ -45,25 +54,25 @@ class StartupConfigISpec extends WordSpec with Matchers with JsonMatchers with F
       appBuilder
         .configure(
           "helpToSave.shuttering.shuttered" -> true,
-          "helpToSave.shuttering.title" -> base64Encode("Shuttered"),
-          "helpToSave.shuttering.message" -> base64Encode("HTS is currently not available"),
-          "helpToSave.supportFormEnabled" -> true
+          "helpToSave.shuttering.title"     -> base64Encode("Shuttered"),
+          "helpToSave.shuttering.message"   -> base64Encode("HTS is currently not available"),
+          "helpToSave.supportFormEnabled"   -> true
         )
         .build()) { (app: Application, portNumber: PortNumber) =>
       implicit val implicitPortNumber: PortNumber = portNumber
-      implicit val wsClient: WSClient = components.wsClient
+      implicit val wsClient:           WSClient   = components.wsClient
 
       AuthStub.userIsLoggedIn(nino)
       HelpToSaveStub.currentUserIsEnrolled()
 
       val response = await(wsUrl("/mobile-help-to-save/startup").get())
 
-      response.status shouldBe 200
+      response.status                                          shouldBe 200
       (response.json \ "shuttering" \ "shuttered").as[Boolean] shouldBe true
-      (response.json \ "shuttering" \ "title").as[String] shouldBe "Shuttered"
-      (response.json \ "shuttering" \ "message").as[String] shouldBe "HTS is currently not available"
-      (response.json \ "supportFormEnabled").as[Boolean] shouldBe true
-      response.json.as[JsObject].keys should not contain "user"
+      (response.json \ "shuttering" \ "title").as[String]      shouldBe "Shuttered"
+      (response.json \ "shuttering" \ "message").as[String]    shouldBe "HTS is currently not available"
+      (response.json \ "supportFormEnabled").as[Boolean]       shouldBe true
+      response.json.as[JsObject].keys                          should not contain "user"
 
       AuthStub.authoriseShouldNotHaveBeenCalled()
       HelpToSaveStub.enrolmentStatusShouldNotHaveBeenCalled()
@@ -73,18 +82,18 @@ class StartupConfigISpec extends WordSpec with Matchers with JsonMatchers with F
       appBuilder
         .build()) { (app: Application, portNumber: PortNumber) =>
       implicit val implicitPortNumber: PortNumber = portNumber
-      implicit val wsClient: WSClient = components.wsClient
+      implicit val wsClient:           WSClient   = components.wsClient
 
       AuthStub.userIsLoggedIn(nino)
       HelpToSaveStub.currentUserIsNotEnrolled()
 
       val response = await(wsUrl("/mobile-help-to-save/startup").get())
-      response.status shouldBe 200
-      (response.json \ "supportFormEnabled" ).validate[Boolean] should beJsSuccess
-      (response.json \ "infoUrl").as[String] shouldBe "https://www.gov.uk/get-help-savings-low-income"
-      (response.json \ "accessAccountUrl").as[String] shouldBe "http://localhost:8249/mobile-help-to-save/access-account"
+      response.status                                          shouldBe 200
+      (response.json \ "supportFormEnabled").validate[Boolean] should beJsSuccess
+      (response.json \ "infoUrl").as[String]                   shouldBe "https://www.gov.uk/get-help-savings-low-income"
+      (response.json \ "accessAccountUrl")
+        .as[String] shouldBe "http://localhost:8249/mobile-help-to-save/access-account"
     }
-
 
     "allow feature flag and URL settings to be overridden in configuration" in {
       AuthStub.userIsLoggedIn(nino)
@@ -93,19 +102,19 @@ class StartupConfigISpec extends WordSpec with Matchers with JsonMatchers with F
       withTestServer(
         appBuilder
           .configure(
-            "helpToSave.infoUrl" -> "http://www.example.com/test/help-to-save-information",
-            "helpToSave.accessAccountUrl" -> "/access-account",
+            "helpToSave.infoUrl"            -> "http://www.example.com/test/help-to-save-information",
+            "helpToSave.accessAccountUrl"   -> "/access-account",
             "helpToSave.supportFormEnabled" -> "true"
           )
           .build()) { (app: Application, portNumber: PortNumber) =>
         implicit val implicitPortNumber: PortNumber = portNumber
-        implicit val wsClient: WSClient = components.wsClient
+        implicit val wsClient:           WSClient   = components.wsClient
 
         val response = await(wsUrl("/mobile-help-to-save/startup").get())
-        response.status shouldBe 200
+        response.status                                    shouldBe 200
         (response.json \ "supportFormEnabled").as[Boolean] shouldBe true
-        (response.json \ "infoUrl").as[String] shouldBe "http://www.example.com/test/help-to-save-information"
-        (response.json \ "accessAccountUrl").as[String] shouldBe "/access-account"
+        (response.json \ "infoUrl").as[String]             shouldBe "http://www.example.com/test/help-to-save-information"
+        (response.json \ "accessAccountUrl").as[String]    shouldBe "/access-account"
       }
 
       withTestServer(
@@ -115,17 +124,16 @@ class StartupConfigISpec extends WordSpec with Matchers with JsonMatchers with F
           )
           .build()) { (app: Application, portNumber: PortNumber) =>
         implicit val implicitPortNumber: PortNumber = portNumber
-        implicit val wsClient: WSClient = components.wsClient
+        implicit val wsClient:           WSClient   = components.wsClient
 
         val response = await(wsUrl("/mobile-help-to-save/startup").get())
-        response.status shouldBe 200
+        response.status                                    shouldBe 200
         (response.json \ "supportFormEnabled").as[Boolean] shouldBe false
       }
     }
 
   }
 
-  private def base64Encode(s: String): String = {
+  private def base64Encode(s: String): String =
     base64Encoder.encodeToString(s.getBytes("UTF-8"))
-  }
 }

--- a/it/uk/gov/hmrc/mobilehelptosave/StartupISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/StartupISpec.scala
@@ -23,16 +23,21 @@ import uk.gov.hmrc.domain.Generator
 import uk.gov.hmrc.mobilehelptosave.stubs.{AuthStub, HelpToSaveStub}
 import uk.gov.hmrc.mobilehelptosave.support.{ComponentSupport, OneServerPerSuiteWsClient, WireMockSupport}
 
-class StartupISpec extends WordSpec with Matchers
-  with FutureAwaits with DefaultAwaitTimeout
-  with WireMockSupport
-  with OneServerPerSuiteWsClient with ComponentSupport with NumberVerification  {
+class StartupISpec
+    extends WordSpec
+    with Matchers
+    with FutureAwaits
+    with DefaultAwaitTimeout
+    with WireMockSupport
+    with OneServerPerSuiteWsClient
+    with ComponentSupport
+    with NumberVerification {
 
   override implicit lazy val app: Application = appBuilder
     .build()
 
   private val generator = new Generator(0)
-  private val nino = generator.nextNino
+  private val nino      = generator.nextNino
 
   "GET /mobile-help-to-save/startup" should {
 
@@ -41,7 +46,7 @@ class StartupISpec extends WordSpec with Matchers
       HelpToSaveStub.currentUserIsEnrolled()
 
       val response = await(wsUrl("/mobile-help-to-save/startup").get())
-      response.status shouldBe 200
+      response.status                                  shouldBe 200
       (response.json \ "user" \ "state").asOpt[String] shouldBe Some("Enrolled")
     }
 
@@ -50,26 +55,26 @@ class StartupISpec extends WordSpec with Matchers
       HelpToSaveStub.enrolmentStatusReturnsInternalServerError()
 
       val response = await(wsUrl("/mobile-help-to-save/startup").get())
-      response.status shouldBe 200
-      (response.json \ "user" \ "state").asOpt[String] shouldBe None
+      response.status                                   shouldBe 200
+      (response.json \ "user" \ "state").asOpt[String]  shouldBe None
       (response.json \ "userError" \ "code").as[String] shouldBe "GENERAL"
       // check that only the user field has been omitted, not all fields
       (response.json \ "supportFormEnabled").asOpt[Boolean] should not be None
-      (response.json \ "infoUrl").asOpt[String] should not be None
+      (response.json \ "infoUrl").asOpt[String]             should not be None
     }
 
     "return 401 when the user is not logged in" in {
       AuthStub.userIsNotLoggedIn()
       val response = await(wsUrl("/mobile-help-to-save/startup").get())
       response.status shouldBe 401
-      response.body shouldBe "Authorisation failure [Bearer token not supplied]"
+      response.body   shouldBe "Authorisation failure [Bearer token not supplied]"
     }
 
     "return 403 Forbidden when the user is logged in with an insufficient confidence level" in {
       AuthStub.userIsLoggedInWithInsufficientConfidenceLevel()
       val response = await(wsUrl("/mobile-help-to-save/startup").get())
       response.status shouldBe 403
-      response.body shouldBe "Authorisation failure [Insufficient ConfidenceLevel]"
+      response.body   shouldBe "Authorisation failure [Insufficient ConfidenceLevel]"
     }
   }
 }

--- a/it/uk/gov/hmrc/mobilehelptosave/TestOnlyRoutesISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/TestOnlyRoutesISpec.scala
@@ -4,15 +4,17 @@ import org.scalatest.{Matchers, WordSpec}
 import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
 import uk.gov.hmrc.mobilehelptosave.support.OneServerPerSuiteWsClient
 
-
 /**
   * Need two separate tests so that the servers can be run with different system
   * property settings for the router
   */
-class TestOnlyRoutesNotWiredISpec extends WordSpec with Matchers
-  with FutureAwaits with DefaultAwaitTimeout
-  with OneServerPerSuiteWsClient {
-  val clearGoalEventsUrl = "/mobile-help-to-save/test-only/clear-goal-events"
+class TestOnlyRoutesNotWiredISpec
+    extends WordSpec
+    with Matchers
+    with FutureAwaits
+    with DefaultAwaitTimeout
+    with OneServerPerSuiteWsClient {
+  val clearGoalEventsUrl           = "/mobile-help-to-save/test-only/clear-goal-events"
   private val applicationRouterKey = "application.router"
 
   System.clearProperty(applicationRouterKey)
@@ -22,10 +24,12 @@ class TestOnlyRoutesNotWiredISpec extends WordSpec with Matchers
   }
 }
 
-
-class TestOnlyRoutesWiredISpec extends WordSpec with Matchers
-  with FutureAwaits with DefaultAwaitTimeout
-  with OneServerPerSuiteWsClient {
+class TestOnlyRoutesWiredISpec
+    extends WordSpec
+    with Matchers
+    with FutureAwaits
+    with DefaultAwaitTimeout
+    with OneServerPerSuiteWsClient {
   val clearGoalEventsUrl = "/mobile-help-to-save/test-only/clear-goal-events"
 
   private val applicationRouterKey = "application.router"

--- a/it/uk/gov/hmrc/mobilehelptosave/TransactionsISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/TransactionsISpec.scala
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2018 HM Revenue & Customs
  *
@@ -29,16 +28,21 @@ import uk.gov.hmrc.mobilehelptosave.scalatest.SchemaMatchers
 import uk.gov.hmrc.mobilehelptosave.stubs.{AuthStub, HelpToSaveStub}
 import uk.gov.hmrc.mobilehelptosave.support.{ComponentSupport, OneServerPerSuiteWsClient, WireMockSupport}
 
-class TransactionsISpec extends WordSpec with Matchers
-  with SchemaMatchers with TransactionTestData
-  with FutureAwaits with DefaultAwaitTimeout
-  with WireMockSupport
-  with OneServerPerSuiteWsClient  with ComponentSupport{
+class TransactionsISpec
+    extends WordSpec
+    with Matchers
+    with SchemaMatchers
+    with TransactionTestData
+    with FutureAwaits
+    with DefaultAwaitTimeout
+    with WireMockSupport
+    with OneServerPerSuiteWsClient
+    with ComponentSupport {
 
   override implicit lazy val app: Application = appBuilder.build()
 
   private val generator = new Generator(0)
-  private val nino = generator.nextNino
+  private val nino      = generator.nextNino
 
   "GET /savings-account/{nino}/transactions" should {
 
@@ -49,7 +53,7 @@ class TransactionsISpec extends WordSpec with Matchers
 
       val response: WSResponse = await(wsUrl(s"/savings-account/$nino/transactions").get())
       response.status shouldBe Status.OK
-      response.json shouldBe Json.parse(transactionsReturnedByMobileHelpToSaveJsonString)
+      response.json   shouldBe Json.parse(transactionsReturnedByMobileHelpToSaveJsonString)
       checkTransactionsResponseInvariants(response)
     }
 
@@ -60,7 +64,7 @@ class TransactionsISpec extends WordSpec with Matchers
 
       val response: WSResponse = await(wsUrl(s"/savings-account/$nino/transactions").get())
       response.status shouldBe Status.OK
-      response.json shouldBe Json.parse(zeroTransactionsReturnedByMobileHelpToSaveJsonString)
+      response.json   shouldBe Json.parse(zeroTransactionsReturnedByMobileHelpToSaveJsonString)
       checkTransactionsResponseInvariants(response)
     }
 
@@ -71,7 +75,7 @@ class TransactionsISpec extends WordSpec with Matchers
 
       val response: WSResponse = await(wsUrl(s"/savings-account/$nino/transactions").get())
       response.status shouldBe Status.OK
-      response.json shouldBe Json.parse(transactionsWithOver50PoundDebitReturnedByMobileHelpToSaveJsonString)
+      response.json   shouldBe Json.parse(transactionsWithOver50PoundDebitReturnedByMobileHelpToSaveJsonString)
       checkTransactionsResponseInvariants(response)
     }
 
@@ -82,7 +86,7 @@ class TransactionsISpec extends WordSpec with Matchers
 
       val response: WSResponse = await(wsUrl(s"/savings-account/$nino/transactions").get())
       response.status shouldBe Status.OK
-      response.json shouldBe Json.parse(multipleTransactionsWithinSameMonthAndDayReturnedByMobileHelpToSaveJsonString)
+      response.json   shouldBe Json.parse(multipleTransactionsWithinSameMonthAndDayReturnedByMobileHelpToSaveJsonString)
       checkTransactionsResponseInvariants(response)
     }
 
@@ -94,7 +98,7 @@ class TransactionsISpec extends WordSpec with Matchers
 
       response.status shouldBe 404
       val jsonBody: JsValue = response.json
-      (jsonBody \ "code").as[String] shouldBe "ACCOUNT_NOT_FOUND"
+      (jsonBody \ "code").as[String]    shouldBe "ACCOUNT_NOT_FOUND"
       (jsonBody \ "message").as[String] shouldBe "No Help to Save account exists for the specified NINO"
       checkTransactionsResponseInvariants(response)
     }
@@ -116,9 +120,8 @@ class TransactionsISpec extends WordSpec with Matchers
     }
   }
 
-  private def checkTransactionsResponseInvariants(response: WSResponse): Assertion = {
+  private def checkTransactionsResponseInvariants(response: WSResponse): Assertion =
     if (response.status == Status.OK) {
       response.json should validateAgainstSchema(strictRamlTransactionsSchema)
     } else succeed
-  }
 }

--- a/it/uk/gov/hmrc/mobilehelptosave/api/ApiDefinitionISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/api/ApiDefinitionISpec.scala
@@ -23,13 +23,21 @@ import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
 import uk.gov.hmrc.mobilehelptosave.support.{ApplicationBuilder, ComponentSupport, OneServerPerSuiteWsClient, WireMockSupport}
 
 class ApiDefinitionISpec
-  extends WordSpec with Matchers with Eventually with FutureAwaits with DefaultAwaitTimeout
-    with WireMockSupport with OneServerPerSuiteWsClient with ComponentSupport {
+    extends WordSpec
+    with Matchers
+    with Eventually
+    with FutureAwaits
+    with DefaultAwaitTimeout
+    with WireMockSupport
+    with OneServerPerSuiteWsClient
+    with ComponentSupport {
 
   override protected def appBuilder: ApplicationBuilder = super.appBuilder.configure(
     "microservice.services.service-locator.host" -> wireMockHost,
     "microservice.services.service-locator.port" -> wireMockPort,
-    "api.access.white-list.applicationIds" -> Seq("00010002-0003-0004-0005-000600070008", "00090002-0003-0004-0005-000600070008"),
+    "api.access.white-list.applicationIds" -> Seq(
+      "00010002-0003-0004-0005-000600070008",
+      "00090002-0003-0004-0005-000600070008"),
     "api.access.type" -> "TEST_ACCESS_TYPE"
   )
 
@@ -49,9 +57,9 @@ class ApiDefinitionISpec
       val accessConfigs = definition \ "api" \ "versions" \\ "access"
       accessConfigs.length should be > 0
       accessConfigs.foreach { accessConfig =>
-        (accessConfig \ "type").as[String] shouldBe "TEST_ACCESS_TYPE"
+        (accessConfig \ "type").as[String]                           shouldBe "TEST_ACCESS_TYPE"
         (accessConfig \ "whitelistedApplicationIds").head.as[String] shouldBe "00010002-0003-0004-0005-000600070008"
-        (accessConfig \ "whitelistedApplicationIds") (1).as[String] shouldBe "00090002-0003-0004-0005-000600070008"
+        (accessConfig \ "whitelistedApplicationIds")(1).as[String]   shouldBe "00090002-0003-0004-0005-000600070008"
       }
     }
   }

--- a/it/uk/gov/hmrc/mobilehelptosave/api/ServiceLocatorRegistrationISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/api/ServiceLocatorRegistrationISpec.scala
@@ -27,26 +27,33 @@ import uk.gov.hmrc.mobilehelptosave.stubs.ServiceLocatorStub
 import uk.gov.hmrc.mobilehelptosave.support.{ApplicationBuilder, ComponentSupport, WireMockSupport}
 
 class ServiceLocatorRegistrationISpec
-  extends WordSpec with Matchers with Eventually
-    with WireMockSupport with ComponentSupport with WithApplicationComponents with PlayRunners{
+    extends WordSpec
+    with Matchers
+    with Eventually
+    with WireMockSupport
+    with ComponentSupport
+    with WithApplicationComponents
+    with PlayRunners {
 
   lazy val app: Application = appBuilder.build()
 
   override protected def appBuilder: ApplicationBuilder = super.appBuilder.configure(
     "microservice.services.service-locator.enabled" -> true,
-    "microservice.services.service-locator.host" -> wireMockHost,
-    "microservice.services.service-locator.port" -> wireMockPort
+    "microservice.services.service-locator.host"    -> wireMockHost,
+    "microservice.services.service-locator.port"    -> wireMockPort
   )
 
   "microservice" should {
     "register itself with the api platform automatically at start up" in {
       ServiceLocatorStub.registrationSucceeds()
 
-      ServiceLocatorStub.registerShouldNotHaveBeenCalled("mobile-help-to-save", "https://mobile-help-to-save.protected.mdtp")
+      ServiceLocatorStub
+        .registerShouldNotHaveBeenCalled("mobile-help-to-save", "https://mobile-help-to-save.protected.mdtp")
 
       running(app) {
         eventually(Timeout(Span(1000 * 20, Millis))) {
-          ServiceLocatorStub.registerShouldHaveBeenCalled("mobile-help-to-save", "https://mobile-help-to-save.protected.mdtp")
+          ServiceLocatorStub
+            .registerShouldHaveBeenCalled("mobile-help-to-save", "https://mobile-help-to-save.protected.mdtp")
         }
       }
     }

--- a/it/uk/gov/hmrc/mobilehelptosave/stubs/AuthStub.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/stubs/AuthStub.scala
@@ -18,11 +18,11 @@ package uk.gov.hmrc.mobilehelptosave.stubs
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.libs.json.Json
 import uk.gov.hmrc.domain.Nino
 
 object AuthStub {
-
 
   private val authoriseRequestBody: String = {
     """
@@ -32,8 +32,7 @@ object AuthStub {
       |}""".stripMargin
   }
 
-
-  def userIsLoggedIn(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
+  def userIsLoggedIn(nino: Nino)(implicit wireMockServer: WireMockServer): StubMapping =
     wireMockServer.stubFor(
       post(urlPathEqualTo("/auth/authorise"))
         .withRequestBody(equalToJson(authoriseRequestBody))
@@ -41,12 +40,14 @@ object AuthStub {
           aResponse()
             .withStatus(200)
             .withBody(
-              Json.obj(
-                "nino" -> nino.value
-              ).toString
+              Json
+                .obj(
+                  "nino" -> nino.value
+                )
+                .toString
             )))
 
-  def userIsLoggedInWithInsufficientConfidenceLevel()(implicit wireMockServer: WireMockServer): Unit =
+  def userIsLoggedInWithInsufficientConfidenceLevel()(implicit wireMockServer: WireMockServer): StubMapping =
     wireMockServer.stubFor(
       post(urlPathEqualTo("/auth/authorise"))
         .withRequestBody(equalToJson(authoriseRequestBody))
@@ -56,7 +57,7 @@ object AuthStub {
             .withHeader("WWW-Authenticate", """MDTP detail="InsufficientConfidenceLevel"""")
         ))
 
-  def userIsNotLoggedIn()(implicit wireMockServer: WireMockServer): Unit =
+  def userIsNotLoggedIn()(implicit wireMockServer: WireMockServer): StubMapping =
     wireMockServer.stubFor(
       post(urlPathEqualTo("/auth/authorise"))
         .withRequestBody(equalToJson(authoriseRequestBody))

--- a/it/uk/gov/hmrc/mobilehelptosave/stubs/HelpToSaveStub.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/stubs/HelpToSaveStub.scala
@@ -18,119 +18,133 @@ package uk.gov.hmrc.mobilehelptosave.stubs
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.http.Status
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.mobilehelptosave.{AccountTestData, TransactionTestData}
 
 object HelpToSaveStub extends AccountTestData with TransactionTestData {
-  def currentUserIsEnrolled()(implicit wireMockServer: WireMockServer): Unit = enrolmentStatusIs(true)
-  def currentUserIsNotEnrolled()(implicit wireMockServer: WireMockServer): Unit = enrolmentStatusIs(false)
+  def currentUserIsEnrolled()(implicit wireMockServer:    WireMockServer): StubMapping = enrolmentStatusIs(status = true)
+  def currentUserIsNotEnrolled()(implicit wireMockServer: WireMockServer): StubMapping = enrolmentStatusIs(status = false)
 
   def enrolmentStatusShouldNotHaveBeenCalled()(implicit wireMockServer: WireMockServer): Unit =
     wireMockServer.verify(0, getRequestedFor(urlPathEqualTo("/help-to-save/enrolment-status")))
 
-  def enrolmentStatusReturnsInternalServerError()(implicit wireMockServer: WireMockServer): Unit =
-    wireMockServer.stubFor(get(urlPathEqualTo("/help-to-save/enrolment-status"))
-      .willReturn(aResponse()
-        .withStatus(Status.INTERNAL_SERVER_ERROR)))
+  def enrolmentStatusReturnsInternalServerError()(implicit wireMockServer: WireMockServer): StubMapping =
+    wireMockServer.stubFor(
+      get(urlPathEqualTo("/help-to-save/enrolment-status"))
+        .willReturn(aResponse()
+          .withStatus(Status.INTERNAL_SERVER_ERROR)))
 
-  private def enrolmentStatusIs(status: Boolean)(implicit wireMockServer: WireMockServer): Unit =
-    wireMockServer.stubFor(get(urlPathEqualTo("/help-to-save/enrolment-status"))
-      .willReturn(aResponse()
-        .withStatus(Status.OK)
-        .withBody(
-          s"""{"enrolled":$status}"""
-        )))
+  private def enrolmentStatusIs(status: Boolean)(implicit wireMockServer: WireMockServer): StubMapping =
+    wireMockServer.stubFor(
+      get(urlPathEqualTo("/help-to-save/enrolment-status"))
+        .willReturn(
+          aResponse()
+            .withStatus(Status.OK)
+            .withBody(
+              s"""{"enrolled":$status}"""
+            )))
 
-  def transactionsExistForUser(nino: Nino)(implicit wireMockServer: WireMockServer): Unit = {
-    wireMockServer.stubFor(get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
-      .willReturn(aResponse()
-        .withStatus(Status.OK)
-        .withBody(transactionsReturnedByHelpToSaveJsonString)))
-  }
+  def transactionsExistForUser(nino: Nino)(implicit wireMockServer: WireMockServer): StubMapping =
+    wireMockServer.stubFor(
+      get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
+        .willReturn(
+          aResponse()
+            .withStatus(Status.OK)
+            .withBody(transactionsReturnedByHelpToSaveJsonString)))
 
-  def zeroTransactionsExistForUser(nino: Nino)(implicit wireMockServer: WireMockServer): Unit = {
-    wireMockServer.stubFor(get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
-      .willReturn(aResponse()
-        .withStatus(Status.OK)
-        .withBody(zeroTransactionsReturnedByHelpToSaveJsonString)))
-  }
+  def zeroTransactionsExistForUser(nino: Nino)(implicit wireMockServer: WireMockServer): StubMapping =
+    wireMockServer.stubFor(
+      get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
+        .willReturn(
+          aResponse()
+            .withStatus(Status.OK)
+            .withBody(zeroTransactionsReturnedByHelpToSaveJsonString)))
 
-  def transactionsWithOver50PoundDebit(nino: Nino)(implicit wireMockServer: WireMockServer): Unit = {
-    wireMockServer.stubFor(get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
-      .willReturn(aResponse()
-        .withStatus(Status.OK)
-        .withBody(transactionsWithOver50PoundDebitReturnedByHelpToSaveJsonString)))
-  }
+  def transactionsWithOver50PoundDebit(nino: Nino)(implicit wireMockServer: WireMockServer): StubMapping =
+    wireMockServer.stubFor(
+      get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
+        .willReturn(
+          aResponse()
+            .withStatus(Status.OK)
+            .withBody(transactionsWithOver50PoundDebitReturnedByHelpToSaveJsonString)))
 
-  def multipleTransactionsWithinSameMonthAndDay(nino: Nino)(implicit wireMockServer: WireMockServer): Unit = {
-    wireMockServer.stubFor(get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
-      .willReturn(aResponse()
-        .withStatus(Status.OK)
-        .withBody(multipleTransactionsWithinSameMonthAndDayReturnedByHelpToSaveJsonString)))
-  }
+  def multipleTransactionsWithinSameMonthAndDay(nino: Nino)(implicit wireMockServer: WireMockServer): StubMapping =
+    wireMockServer.stubFor(
+      get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
+        .willReturn(
+          aResponse()
+            .withStatus(Status.OK)
+            .withBody(multipleTransactionsWithinSameMonthAndDayReturnedByHelpToSaveJsonString)))
 
-  def userDoesNotHaveAnHtsAccount(nino: Nino)(implicit wireMockServer: WireMockServer): Unit = {
-    wireMockServer.stubFor(get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
-      .willReturn(aResponse()
-        .withStatus(Status.NOT_FOUND)))
-  }
+  def userDoesNotHaveAnHtsAccount(nino: Nino)(implicit wireMockServer: WireMockServer): StubMapping =
+    wireMockServer.stubFor(
+      get(urlPathEqualTo(s"/help-to-save/$nino/account/transactions"))
+        .willReturn(aResponse()
+          .withStatus(Status.NOT_FOUND)))
 
-  private def getAccountUrlPathPattern(nino: Nino) = {
+  private def getAccountUrlPathPattern(nino: Nino) =
     urlPathEqualTo(s"/help-to-save/$nino/account")
-  }
 
   def accountShouldNotHaveBeenCalled(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
     wireMockServer.verify(0, getRequestedFor(getAccountUrlPathPattern(nino)))
 
-  def accountExists(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
-    wireMockServer.stubFor(get(getAccountUrlPathPattern(nino))
-      .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
-      .willReturn(aResponse()
-        .withStatus(200)
-        .withBody(accountReturnedByHelpToSaveJsonString)))
+  def accountExists(nino: Nino)(implicit wireMockServer: WireMockServer): StubMapping =
+    wireMockServer.stubFor(
+      get(getAccountUrlPathPattern(nino))
+        .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
+        .willReturn(aResponse()
+          .withStatus(200)
+          .withBody(accountReturnedByHelpToSaveJsonString)))
 
-  def accountExistsWithNoEmail(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
-    wireMockServer.stubFor(get(getAccountUrlPathPattern(nino))
-      .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
-      .willReturn(aResponse()
-        .withStatus(200)
-        .withBody(accountWithNoEmailReturnedByHelpToSaveJsonString)))
+  def accountExistsWithNoEmail(nino: Nino)(implicit wireMockServer: WireMockServer): StubMapping =
+    wireMockServer.stubFor(
+      get(getAccountUrlPathPattern(nino))
+        .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
+        .willReturn(aResponse()
+          .withStatus(200)
+          .withBody(accountWithNoEmailReturnedByHelpToSaveJsonString)))
 
-  def closedAccountExists(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
-    wireMockServer.stubFor(get(getAccountUrlPathPattern(nino))
-      .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
-      .willReturn(aResponse()
-        .withStatus(200)
-        .withBody(closedAccountReturnedByHelpToSaveJsonString)))
+  def closedAccountExists(nino: Nino)(implicit wireMockServer: WireMockServer): StubMapping =
+    wireMockServer.stubFor(
+      get(getAccountUrlPathPattern(nino))
+        .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
+        .willReturn(aResponse()
+          .withStatus(200)
+          .withBody(closedAccountReturnedByHelpToSaveJsonString)))
 
-  def blockedAccountExists(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
-    wireMockServer.stubFor(get(getAccountUrlPathPattern(nino))
-      .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
-      .willReturn(aResponse()
-        .withStatus(200)
-        .withBody(enrolledButBlockedReturnedByHelpToSaveJsonString)))
+  def blockedAccountExists(nino: Nino)(implicit wireMockServer: WireMockServer): StubMapping =
+    wireMockServer.stubFor(
+      get(getAccountUrlPathPattern(nino))
+        .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
+        .willReturn(aResponse()
+          .withStatus(200)
+          .withBody(enrolledButBlockedReturnedByHelpToSaveJsonString)))
 
+  def accountReturnsInvalidJson(nino: Nino)(implicit wireMockServer: WireMockServer): StubMapping =
+    wireMockServer.stubFor(
+      get(getAccountUrlPathPattern(nino))
+        .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
+        .willReturn(aResponse()
+          .withStatus(200)
+          .withBody(accountReturnedByHelpToSaveInvalidJsonString)))
 
-  def accountReturnsInvalidJson(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
-    wireMockServer.stubFor(get(getAccountUrlPathPattern(nino))
-      .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
-      .willReturn(aResponse()
-        .withStatus(200)
-        .withBody(accountReturnedByHelpToSaveInvalidJsonString)))
+  def accountReturnsBadlyFormedJson(nino: Nino)(implicit wireMockServer: WireMockServer): StubMapping =
+    wireMockServer.stubFor(
+      get(getAccountUrlPathPattern(nino))
+        .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withBody(
+              """not JSON""".stripMargin
+            )))
 
-  def accountReturnsBadlyFormedJson(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
-    wireMockServer.stubFor(get(getAccountUrlPathPattern(nino))
-      .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
-      .willReturn(aResponse()
-        .withStatus(200)
-        .withBody(
-          """not JSON""".stripMargin
-        )))
-
-  def accountReturnsInternalServerError(nino: Nino)(implicit wireMockServer: WireMockServer): Unit =
-    wireMockServer.stubFor(get(getAccountUrlPathPattern(nino))
-      .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
-      .willReturn(aResponse()
-        .withStatus(500)))
+  def accountReturnsInternalServerError(nino: Nino)(implicit wireMockServer: WireMockServer): StubMapping =
+    wireMockServer.stubFor(
+      get(getAccountUrlPathPattern(nino))
+        .withQueryParam("systemId", equalTo("MDTP-MOBILE"))
+        .willReturn(aResponse()
+          .withStatus(500)))
 }

--- a/it/uk/gov/hmrc/mobilehelptosave/stubs/ServiceLocatorStub.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/stubs/ServiceLocatorStub.scala
@@ -19,27 +19,32 @@ package uk.gov.hmrc.mobilehelptosave.stubs
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.libs.json.Json
 import uk.gov.hmrc.api.domain.Registration
 
 object ServiceLocatorStub {
 
-  def registerShouldHaveBeenCalled(serviceName: String, serviceUrl: String)(implicit wireMockServer: WireMockServer): Unit =
+  def registerShouldHaveBeenCalled(serviceName: String, serviceUrl: String)(
+    implicit wireMockServer:                    WireMockServer): Unit =
     wireMockServer.verify(1, registrationPattern(serviceName, serviceUrl))
 
-  def registerShouldNotHaveBeenCalled(serviceName: String, serviceUrl: String)(implicit wireMockServer: WireMockServer): Unit =
+  def registerShouldNotHaveBeenCalled(serviceName: String, serviceUrl: String)(
+    implicit wireMockServer:                       WireMockServer): Unit =
     wireMockServer.verify(0, registrationPattern(serviceName, serviceUrl))
 
-  def registrationSucceeds()(implicit wireMockServer: WireMockServer): Unit =
-    wireMockServer.stubFor(post(urlPathEqualTo("/registration"))
-      .willReturn(aResponse()
-        .withStatus(204)))
+  def registrationSucceeds()(implicit wireMockServer: WireMockServer): StubMapping =
+    wireMockServer.stubFor(
+      post(urlPathEqualTo("/registration"))
+        .willReturn(aResponse()
+          .withStatus(204)))
 
   private def regPayloadStringFor(serviceName: String, serviceUrl: String): String =
     Json.toJson(Registration(serviceName, serviceUrl, Some(Map("third-party-api" -> "true")))).toString
 
-  private def registrationPattern(serviceName: String, serviceUrl: String): RequestPatternBuilder = postRequestedFor(urlPathEqualTo("/registration"))
-    .withHeader("content-type", equalTo("application/json"))
-    .withRequestBody(equalTo(regPayloadStringFor(serviceName, serviceUrl)))
+  private def registrationPattern(serviceName: String, serviceUrl: String): RequestPatternBuilder =
+    postRequestedFor(urlPathEqualTo("/registration"))
+      .withHeader("content-type", equalTo("application/json"))
+      .withRequestBody(equalTo(regPayloadStringFor(serviceName, serviceUrl)))
 
 }

--- a/it/uk/gov/hmrc/mobilehelptosave/support/AppBuilder.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/support/AppBuilder.scala
@@ -25,7 +25,8 @@ trait ApplicationBuilder {
   def configure(conf: (String, Any)*): ApplicationBuilder
 }
 
-class ComponentApplicationBuilder(context: Context = ApplicationLoader.createContext(Environment.simple())) extends ApplicationBuilder {
+class ComponentApplicationBuilder(context: Context = ApplicationLoader.createContext(Environment.simple()))
+    extends ApplicationBuilder {
   override def build(): Application =
     new ServiceComponents(context).application
 
@@ -40,7 +41,6 @@ class ComponentApplicationBuilder(context: Context = ApplicationLoader.createCon
     */
   final def configure(conf: Map[String, Any]): ComponentApplicationBuilder =
     configure(Configuration.from(conf))
-
 
 }
 

--- a/it/uk/gov/hmrc/mobilehelptosave/support/OneServerPerSuiteWsClient.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/support/OneServerPerSuiteWsClient.scala
@@ -25,8 +25,8 @@ import play.api.libs.ws.WSClient
   * Provides implicits so that the server started by OneServerPerSuite can
   * be called using the methods in WsScalaTestClient
   */
-trait OneServerPerSuiteWsClient extends OneServerPerSuiteWithComponents with ComponentSupport with WsScalaTestClient  {
+trait OneServerPerSuiteWsClient extends OneServerPerSuiteWithComponents with ComponentSupport with WsScalaTestClient {
   this: TestSuite =>
   implicit lazy val implicitPortNumber: PortNumber = portNumber
-  implicit lazy val wsClient          : WSClient   = components.wsClient
+  implicit lazy val wsClient:           WSClient   = components.wsClient
 }

--- a/it/uk/gov/hmrc/mobilehelptosave/support/WireMockSupport.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/support/WireMockSupport.scala
@@ -29,9 +29,9 @@ trait WireMockSupport extends BeforeAndAfterAll with BeforeAndAfterEach with App
   me: Suite =>
 
   lazy val wireMockPort: Int = wireMockServer.port
-  val wireMockHost = "localhost"
+  val wireMockHost                 = "localhost"
   lazy val wireMockBaseUrlAsString = s"http://$wireMockHost:$wireMockPort"
-  lazy val wireMockBaseUrl = new URL(wireMockBaseUrlAsString)
+  lazy val wireMockBaseUrl         = new URL(wireMockBaseUrlAsString)
   protected implicit lazy val implicitWireMockBaseUrl: WireMockBaseUrl = WireMockBaseUrl(wireMockBaseUrl)
 
   protected def basicWireMockConfig(): WireMockConfiguration = wireMockConfig()
@@ -53,8 +53,8 @@ trait WireMockSupport extends BeforeAndAfterAll with BeforeAndAfterEach with App
   }
 
   override protected def appBuilder: ApplicationBuilder = super.appBuilder.configure(
-    "auditing.enabled" -> false,
-    "microservice.services.auth.port" -> wireMockPort,
+    "auditing.enabled"                        -> false,
+    "microservice.services.auth.port"         -> wireMockPort,
     "microservice.services.help-to-save.port" -> wireMockPort
   )
 }

--- a/test/uk/gov/hmrc/mobilehelptosave/api/DocumentationControllerSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/api/DocumentationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,7 @@ import play.api.mvc.Result
 import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
 import uk.gov.hmrc.mobilehelptosave.config.DocumentationControllerConfig
 
-class DocumentationControllerSpec
-  extends WordSpec with Matchers
-    with FutureAwaits with DefaultAwaitTimeout  {
+class DocumentationControllerSpec extends WordSpec with Matchers with FutureAwaits with DefaultAwaitTimeout {
   "definition" should {
     "have content type = application/json" in {
       val controller = new DocumentationController(LazyHttpErrorHandler, TestDocumentationControllerConfig)
@@ -35,6 +33,6 @@ class DocumentationControllerSpec
 }
 
 private object TestDocumentationControllerConfig extends DocumentationControllerConfig {
-  override def apiAccessType = "PRIVATE"
+  override def apiAccessType              = "PRIVATE"
   override def apiWhiteListApplicationIds = Seq.empty[String]
 }

--- a/test/uk/gov/hmrc/mobilehelptosave/config/Base64Spec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/config/Base64Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/SandboxControllerSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/SandboxControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import uk.gov.hmrc.mobilehelptosave.{AccountTestData, NumberVerification, Transa
 import scala.concurrent.Future
 
 class SandboxControllerSpec
-  extends WordSpec
+    extends WordSpec
     with Matchers
     with SchemaMatchers
     with MockFactory
@@ -50,22 +50,30 @@ class SandboxControllerSpec
     with NumberVerification {
 
   private implicit val hc: HeaderCarrier = HeaderCarrier()
-  private val generator = new Generator(0)
-  private val nino = generator.nextNino
-  private val shuttering = Shuttering(shuttered = false, "", "")
+  private val generator           = new Generator(0)
+  private val nino                = generator.nextNino
+  private val shuttering          = Shuttering(shuttered = false, "", "")
   private val shutteredShuttering = Shuttering(shuttered = true, "Gad Dangit!", "This service is shuttered")
-  private val config = TestHelpToSaveControllerConfig(shuttering)
-  private val currentTime = new DateTime(2018, 9, 29, 12, 30, DateTimeZone.forID("Europe/London"))
-  private val fixedClock = new FixedFakeClock(currentTime)
-  private val controller: SandboxController = new SandboxController(logger, config, SandboxData(logger, fixedClock, TestSandboxDataConfig))
-  private val shutteredController: SandboxController = new SandboxController(logger, config.copy(shuttering = shutteredShuttering), SandboxData(logger, fixedClock, TestSandboxDataConfig))
+  private val config              = TestHelpToSaveControllerConfig(shuttering)
+  private val currentTime         = new DateTime(2018, 9, 29, 12, 30, DateTimeZone.forID("Europe/London"))
+  private val fixedClock          = new FixedFakeClock(currentTime)
+  private val controller: SandboxController =
+    new SandboxController(logger, config, SandboxData(logger, fixedClock, TestSandboxDataConfig))
+  private val shutteredController: SandboxController = new SandboxController(
+    logger,
+    config.copy(shuttering = shutteredShuttering),
+    SandboxData(logger, fixedClock, TestSandboxDataConfig))
 
   implicit class TransactionJson(json: JsValue) {
-    def operation(transactionIndex: Int): String = ((json \ "transactions") (transactionIndex) \ "operation").as[String]
-    def amount(transactionIndex: Int): BigDecimal = ((json \ "transactions") (transactionIndex) \ "amount").as[BigDecimal]
-    def transactionDate(transactionIndex: Int): String = ((json \ "transactions") (transactionIndex) \ "transactionDate").as[String]
-    def accountingDate(transactionIndex: Int): String = ((json \ "transactions") (transactionIndex) \ "accountingDate").as[String]
-    def balanceAfter(transactionIndex: Int): BigDecimal = ((json \ "transactions") (transactionIndex) \ "balanceAfter").as[BigDecimal]
+    def operation(transactionIndex: Int): String = ((json \ "transactions")(transactionIndex) \ "operation").as[String]
+    def amount(transactionIndex:    Int): BigDecimal =
+      ((json \ "transactions")(transactionIndex) \ "amount").as[BigDecimal]
+    def transactionDate(transactionIndex: Int): String =
+      ((json \ "transactions")(transactionIndex) \ "transactionDate").as[String]
+    def accountingDate(transactionIndex: Int): String =
+      ((json \ "transactions")(transactionIndex) \ "accountingDate").as[String]
+    def balanceAfter(transactionIndex: Int): BigDecimal =
+      ((json \ "transactions")(transactionIndex) \ "balanceAfter").as[BigDecimal]
     def transactionCount(): Int = (json \ "transactions").as[JsArray].value.length
   }
 
@@ -77,91 +85,92 @@ class SandboxControllerSpec
       status(response) shouldBe OK
       val json: JsValue = contentAsJson(response)
 
-      json transactionCount() shouldBe 11
+      json transactionCount () shouldBe 11
 
       var atIndex = 0
-      json operation atIndex shouldBe "credit"
-      json amount atIndex shouldBe BigDecimal(20.5)
+      json operation atIndex       shouldBe "credit"
+      json amount atIndex          shouldBe BigDecimal(20.5)
       json transactionDate atIndex shouldBe "2018-09-29"
-      json accountingDate atIndex shouldBe "2018-09-29"
-      json balanceAfter atIndex shouldBe BigDecimal(220.5)
+      json accountingDate atIndex  shouldBe "2018-09-29"
+      json balanceAfter atIndex    shouldBe BigDecimal(220.5)
 
       atIndex = 1
-      json operation atIndex shouldBe "credit"
-      json amount atIndex shouldBe BigDecimal(20)
+      json operation atIndex       shouldBe "credit"
+      json amount atIndex          shouldBe BigDecimal(20)
       json transactionDate atIndex shouldBe "2018-08-29"
-      json accountingDate atIndex shouldBe "2018-08-29"
-      json balanceAfter atIndex shouldBe BigDecimal(200)
+      json accountingDate atIndex  shouldBe "2018-08-29"
+      json balanceAfter atIndex    shouldBe BigDecimal(200)
 
       atIndex = 2
-      json operation atIndex shouldBe "credit"
-      json amount atIndex shouldBe BigDecimal(18.2)
+      json operation atIndex       shouldBe "credit"
+      json amount atIndex          shouldBe BigDecimal(18.2)
       json transactionDate atIndex shouldBe "2018-08-29"
-      json accountingDate atIndex shouldBe "2018-08-29"
-      json balanceAfter atIndex shouldBe BigDecimal(180)
+      json accountingDate atIndex  shouldBe "2018-08-29"
+      json balanceAfter atIndex    shouldBe BigDecimal(180)
 
       atIndex = 3
-      json operation atIndex shouldBe "credit"
-      json amount atIndex shouldBe BigDecimal(10.4)
+      json operation atIndex       shouldBe "credit"
+      json amount atIndex          shouldBe BigDecimal(10.4)
       json transactionDate atIndex shouldBe "2018-07-29"
-      json accountingDate atIndex shouldBe "2018-07-29"
-      json balanceAfter atIndex shouldBe BigDecimal(161.8)
+      json accountingDate atIndex  shouldBe "2018-07-29"
+      json balanceAfter atIndex    shouldBe BigDecimal(161.8)
 
       atIndex = 4
-      json operation atIndex shouldBe "credit"
-      json amount atIndex shouldBe BigDecimal(35)
+      json operation atIndex       shouldBe "credit"
+      json amount atIndex          shouldBe BigDecimal(35)
       json transactionDate atIndex shouldBe "2018-06-29"
-      json accountingDate atIndex shouldBe "2018-06-29"
-      json balanceAfter atIndex shouldBe BigDecimal(151.4)
+      json accountingDate atIndex  shouldBe "2018-06-29"
+      json balanceAfter atIndex    shouldBe BigDecimal(151.4)
 
       atIndex = 5
-      json operation atIndex shouldBe "credit"
-      json amount atIndex shouldBe BigDecimal(15)
+      json operation atIndex       shouldBe "credit"
+      json amount atIndex          shouldBe BigDecimal(15)
       json transactionDate atIndex shouldBe "2018-06-29"
-      json accountingDate atIndex shouldBe "2018-06-29"
-      json balanceAfter atIndex shouldBe BigDecimal(116.4)
+      json accountingDate atIndex  shouldBe "2018-06-29"
+      json balanceAfter atIndex    shouldBe BigDecimal(116.4)
 
       atIndex = 6
-      json operation atIndex shouldBe "credit"
-      json amount atIndex shouldBe BigDecimal(6)
+      json operation atIndex       shouldBe "credit"
+      json amount atIndex          shouldBe BigDecimal(6)
       json transactionDate atIndex shouldBe "2018-05-29"
-      json accountingDate atIndex shouldBe "2018-05-29"
-      json balanceAfter atIndex shouldBe BigDecimal(101.4)
+      json accountingDate atIndex  shouldBe "2018-05-29"
+      json balanceAfter atIndex    shouldBe BigDecimal(101.4)
 
       atIndex = 7
-      json operation atIndex shouldBe "credit"
-      json amount atIndex shouldBe BigDecimal(20.4)
+      json operation atIndex       shouldBe "credit"
+      json amount atIndex          shouldBe BigDecimal(20.4)
       json transactionDate atIndex shouldBe "2018-04-29"
-      json accountingDate atIndex shouldBe "2018-04-29"
-      json balanceAfter atIndex shouldBe BigDecimal(95.4)
+      json accountingDate atIndex  shouldBe "2018-04-29"
+      json balanceAfter atIndex    shouldBe BigDecimal(95.4)
 
       atIndex = 8
-      json operation atIndex shouldBe "credit"
-      json amount atIndex shouldBe BigDecimal(10)
+      json operation atIndex       shouldBe "credit"
+      json amount atIndex          shouldBe BigDecimal(10)
       json transactionDate atIndex shouldBe "2018-04-29"
-      json accountingDate atIndex shouldBe "2018-04-29"
-      json balanceAfter atIndex shouldBe BigDecimal(75)
+      json accountingDate atIndex  shouldBe "2018-04-29"
+      json balanceAfter atIndex    shouldBe BigDecimal(75)
 
       atIndex = 9
-      json operation atIndex shouldBe "credit"
-      json amount atIndex shouldBe BigDecimal(25)
+      json operation atIndex       shouldBe "credit"
+      json amount atIndex          shouldBe BigDecimal(25)
       json transactionDate atIndex shouldBe "2018-03-29"
-      json accountingDate atIndex shouldBe "2018-03-29"
-      json balanceAfter atIndex shouldBe BigDecimal(65)
+      json accountingDate atIndex  shouldBe "2018-03-29"
+      json balanceAfter atIndex    shouldBe BigDecimal(65)
 
       atIndex = 10
-      json operation atIndex shouldBe "credit"
-      json amount atIndex shouldBe BigDecimal(40)
+      json operation atIndex       shouldBe "credit"
+      json amount atIndex          shouldBe BigDecimal(40)
       json transactionDate atIndex shouldBe "2018-02-28"
-      json accountingDate atIndex shouldBe "2018-02-28"
-      json balanceAfter atIndex shouldBe BigDecimal(40)
+      json accountingDate atIndex  shouldBe "2018-02-28"
+      json balanceAfter atIndex    shouldBe BigDecimal(40)
     }
 
     "return a shuttered response when the service is shuttered" in {
 
       val response: Future[Result] = shutteredController.getTransactions(nino.value)(FakeRequest())
       status(response) shouldBe 521
-      contentAsJson(response).as[Shuttering] shouldBe Shuttering(shuttered = true, "Gad Dangit!", "This service is shuttered")
+      contentAsJson(response)
+        .as[Shuttering] shouldBe Shuttering(shuttered = true, "Gad Dangit!", "This service is shuttered")
     }
   }
 
@@ -173,26 +182,26 @@ class SandboxControllerSpec
       status(response) shouldBe OK
       val json: JsValue = contentAsJson(response)
 
-      (json \ "number").as[String] shouldBe "1100000112057"
-      (json \ "openedYearMonth").as[String] shouldBe "2018-02"
-      (json \ "isClosed").as[Boolean] shouldBe false
-      (json \ "blocked" \ "unspecified").as[Boolean] shouldBe false
-      (json \ "balance").as[BigDecimal] shouldBe BigDecimal(220.5)
-      (json \ "paidInThisMonth").as[BigDecimal] shouldBe BigDecimal(20.5)
-      (json \ "canPayInThisMonth").as[BigDecimal] shouldBe BigDecimal(29.5)
+      (json \ "number").as[String]                     shouldBe "1100000112057"
+      (json \ "openedYearMonth").as[String]            shouldBe "2018-02"
+      (json \ "isClosed").as[Boolean]                  shouldBe false
+      (json \ "blocked" \ "unspecified").as[Boolean]   shouldBe false
+      (json \ "balance").as[BigDecimal]                shouldBe BigDecimal(220.5)
+      (json \ "paidInThisMonth").as[BigDecimal]        shouldBe BigDecimal(20.5)
+      (json \ "canPayInThisMonth").as[BigDecimal]      shouldBe BigDecimal(29.5)
       (json \ "maximumPaidInThisMonth").as[BigDecimal] shouldBe BigDecimal(50)
-      (json \ "thisMonthEndDate").as[String] shouldBe "2018-09-30"
+      (json \ "thisMonthEndDate").as[String]           shouldBe "2018-09-30"
 
-      val firstBonusTermJson: JsLookupResult = (json \ "bonusTerms") (0)
+      val firstBonusTermJson: JsLookupResult = (json \ "bonusTerms")(0)
       shouldBeBigDecimal(firstBonusTermJson \ "bonusEstimate", BigDecimal("110.25"))
       shouldBeBigDecimal(firstBonusTermJson \ "bonusPaid", BigDecimal("0"))
-      (firstBonusTermJson \ "endDate").as[String] shouldBe "2020-01-31"
+      (firstBonusTermJson \ "endDate").as[String]                shouldBe "2020-01-31"
       (firstBonusTermJson \ "bonusPaidOnOrAfterDate").as[String] shouldBe "2020-02-01"
 
-      val secondBonusTermJson: JsLookupResult = (json \ "bonusTerms") (1)
+      val secondBonusTermJson: JsLookupResult = (json \ "bonusTerms")(1)
       shouldBeBigDecimal(secondBonusTermJson \ "bonusEstimate", BigDecimal(0))
       shouldBeBigDecimal(secondBonusTermJson \ "bonusPaid", BigDecimal(0))
-      (secondBonusTermJson \ "endDate").as[String] shouldBe "2022-01-31"
+      (secondBonusTermJson \ "endDate").as[String]                shouldBe "2022-01-31"
       (secondBonusTermJson \ "bonusPaidOnOrAfterDate").as[String] shouldBe "2022-02-01"
 
       (json \ "inAppPaymentsEnabled").as[Boolean] shouldBe false
@@ -202,7 +211,8 @@ class SandboxControllerSpec
 
       val response: Future[Result] = shutteredController.getAccount(nino.value)(FakeRequest())
       status(response) shouldBe 521
-      contentAsJson(response).as[Shuttering] shouldBe Shuttering(shuttered = true, "Gad Dangit!", "This service is shuttered")
+      contentAsJson(response)
+        .as[Shuttering] shouldBe Shuttering(shuttered = true, "Gad Dangit!", "This service is shuttered")
     }
   }
 }

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/StartupControllerSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/StartupControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class StartupControllerSpec
-  extends WordSpec
+    extends WordSpec
     with Matchers
     with MockFactory
     with OneInstancePerTest
@@ -50,8 +50,8 @@ class StartupControllerSpec
 
   private val config = TestStartupControllerConfig(
     falseShuttering,
-    supportFormEnabled = false,
-    helpToSaveInfoUrl = "/info",
+    supportFormEnabled         = false,
+    helpToSaveInfoUrl          = "/info",
     helpToSaveAccessAccountUrl = "/accessAccount"
   )
 
@@ -59,23 +59,18 @@ class StartupControllerSpec
 
   "startup" should {
     "pass NINO obtained from auth into userService" in {
-      (mockUserService.userDetails(_: Nino)(_: HeaderCarrier))
+      (mockUserService
+        .userDetails(_: Nino)(_: HeaderCarrier))
         .expects(nino, *)
         .returning(Future successful Right(testUserDetails))
 
-      val controller = new StartupController(
-        mockUserService,
-        new AlwaysAuthorisedWithIds(nino),
-        config)
+      val controller = new StartupController(mockUserService, new AlwaysAuthorisedWithIds(nino), config)
 
       status(controller.startup(FakeRequest())) shouldBe 200
     }
 
     "check permissions using AuthorisedWithIds" in {
-      val controller = new StartupController(
-        mockUserService,
-        NeverAuthorisedWithIds,
-        config)
+      val controller = new StartupController(mockUserService, NeverAuthorisedWithIds, config)
 
       status(controller.startup()(FakeRequest())) shouldBe 403
     }
@@ -83,13 +78,11 @@ class StartupControllerSpec
 
   "startup" when {
     "helpToSaveEnabled = true and helpToSaveShuttered = false" should {
-      val controller = new StartupController(
-        mockUserService,
-        new AlwaysAuthorisedWithIds(nino),
-        config)
+      val controller = new StartupController(mockUserService, new AlwaysAuthorisedWithIds(nino), config)
 
       "include URLs and user in response" in {
-        (mockUserService.userDetails(_: Nino)(_: HeaderCarrier))
+        (mockUserService
+          .userDetails(_: Nino)(_: HeaderCarrier))
           .expects(nino, *)
           .returning(Future successful Right(testUserDetails))
 
@@ -97,13 +90,14 @@ class StartupControllerSpec
         status(resultF) shouldBe 200
         val jsonBody = contentAsJson(resultF)
         val jsonKeys = jsonBody.as[JsObject].keys
-        jsonKeys should contain("user")
-        (jsonBody \ "infoUrl").as[String] shouldBe "/info"
+        jsonKeys                                   should contain("user")
+        (jsonBody \ "infoUrl").as[String]          shouldBe "/info"
         (jsonBody \ "accessAccountUrl").as[String] shouldBe "/accessAccount"
       }
 
       "include shuttering information in response with shuttered = false" in {
-        (mockUserService.userDetails(_: Nino)(_: HeaderCarrier))
+        (mockUserService
+          .userDetails(_: Nino)(_: HeaderCarrier))
           .expects(nino, *)
           .returning(Future successful Right(testUserDetails))
 
@@ -115,16 +109,14 @@ class StartupControllerSpec
     }
 
     "there is an error getting user details" should {
-      val controller = new StartupController(
-        mockUserService,
-        new AlwaysAuthorisedWithIds(nino),
-        config)
+      val controller = new StartupController(mockUserService, new AlwaysAuthorisedWithIds(nino), config)
 
       "include userError and non-user fields such as URLs response" in {
         val generator = new Generator(0)
-        val nino = generator.nextNino
+        val nino      = generator.nextNino
 
-        (mockUserService.userDetails(_: Nino)(_: HeaderCarrier))
+        (mockUserService
+          .userDetails(_: Nino)(_: HeaderCarrier))
           .expects(nino, *)
           .returning(Future successful Left(ErrorInfo.General))
 
@@ -132,10 +124,10 @@ class StartupControllerSpec
         status(resultF) shouldBe 200
         val jsonBody = contentAsJson(resultF)
         val jsonKeys = jsonBody.as[JsObject].keys
-        jsonKeys should not contain "user"
+        jsonKeys                                     should not contain "user"
         (jsonBody \ "userError" \ "code").as[String] shouldBe "GENERAL"
-        (jsonBody \ "infoUrl").as[String] shouldBe "/info"
-        (jsonBody \ "accessAccountUrl").as[String] shouldBe "/accessAccount"
+        (jsonBody \ "infoUrl").as[String]            shouldBe "/info"
+        (jsonBody \ "accessAccountUrl").as[String]   shouldBe "/accessAccount"
       }
     }
 
@@ -160,8 +152,8 @@ class StartupControllerSpec
         status(resultF) shouldBe 200
         val jsonBody = contentAsJson(resultF)
         (jsonBody \ "shuttering" \ "shuttered").as[Boolean] shouldBe true
-        (jsonBody \ "shuttering" \ "title").as[String] shouldBe "Shuttered"
-        (jsonBody \ "shuttering" \ "message").as[String] shouldBe "HTS is currently not available"
+        (jsonBody \ "shuttering" \ "title").as[String]      shouldBe "Shuttered"
+        (jsonBody \ "shuttering" \ "message").as[String]    shouldBe "HTS is currently not available"
       }
 
       "continue to include feature flags because some of them take priority over shuttering" in {
@@ -185,16 +177,16 @@ class StartupControllerSpec
         status(resultF) shouldBe 200
         val jsonBody = contentAsJson(resultF)
         (jsonBody \ "shuttering" \ "shuttered").as[Boolean] shouldBe true
-        (jsonBody \ "shuttering" \ "title").as[String] shouldBe "something"
-        (jsonBody \ "shuttering" \ "message").as[String] shouldBe "some message"
+        (jsonBody \ "shuttering" \ "title").as[String]      shouldBe "something"
+        (jsonBody \ "shuttering" \ "message").as[String]    shouldBe "some message"
       }
     }
   }
 }
 
 case class TestStartupControllerConfig(
-  shuttering: Shuttering,
-  supportFormEnabled: Boolean,
-  helpToSaveInfoUrl: String,
+  shuttering:                 Shuttering,
+  supportFormEnabled:         Boolean,
+  helpToSaveInfoUrl:          String,
   helpToSaveAccessAccountUrl: String
 ) extends StartupControllerConfig

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/TestAuthorisedWithIds.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/TestAuthorisedWithIds.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/GetAccountSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/GetAccountSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import scala.concurrent.Future
 
 //noinspection TypeAnnotation
 class GetAccountSpec
-  extends WordSpec
+    extends WordSpec
     with Matchers
     with SchemaMatchers
     with FutureAwaits
@@ -58,7 +58,7 @@ class GetAccountSpec
   "getAccount" when {
     "logged in user's NINO matches NINO in URL" should {
       "return 200 with the users account information obtained by passing NINO to AccountService" in new AuthorisedTestScenario
-        with HelpToSaveMocking {
+      with HelpToSaveMocking {
 
         accountReturns(Right(Some(mobileHelpToSaveAccount)))
 
@@ -70,8 +70,7 @@ class GetAccountSpec
     }
 
     "there is a savings goal associated with the NINO" should {
-      "return the savings goal in the account structure" in new AuthorisedTestScenario
-        with HelpToSaveMocking {
+      "return the savings goal in the account structure" in new AuthorisedTestScenario with HelpToSaveMocking {
         accountReturns(Right(Some(mobileHelpToSaveAccount)))
 
         val accountData = controller.getAccount(nino.value)(FakeRequest())
@@ -92,7 +91,7 @@ class GetAccountSpec
         (jsonBody \ "message")
           .as[String] shouldBe "No Help to Save account exists for the specified NINO"
 
-        (slf4jLoggerStub.warn(_: String)) verify * never()
+        (slf4jLoggerStub.warn(_: String)) verify * never ()
       }
     }
 
@@ -146,7 +145,7 @@ class GetAccountSpec
 
     "helpToSaveShuttered = true" should {
       """return 521 "shuttered": true""" in {
-        val accountService = mock[AccountService[Future]]
+        val accountService            = mock[AccountService[Future]]
         val helpToSaveGetTransactions = mock[HelpToSaveGetTransactions[Future]]
         val controller = new HelpToSaveController(
           logger,
@@ -160,7 +159,7 @@ class GetAccountSpec
         status(resultF) shouldBe 521
         val jsonBody = contentAsJson(resultF)
         (jsonBody \ "shuttered").as[Boolean] shouldBe true
-        (jsonBody \ "title").as[String] shouldBe "Shuttered"
+        (jsonBody \ "title").as[String]      shouldBe "Shuttered"
         (jsonBody \ "message")
           .as[String] shouldBe "HTS is currently not available"
       }

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/GetTransactionsSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/GetTransactionsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import scala.concurrent.Future
 
 //noinspection TypeAnnotation
 class GetTransactionsSpec
-  extends WordSpec
+    extends WordSpec
     with Matchers
     with SchemaMatchers
     with FutureAwaits
@@ -57,7 +57,8 @@ class GetTransactionsSpec
 
   "getTransactions" when {
     "logged in user's NINO matches NINO in URL" should {
-      "return 200 with transactions obtained by passing NINO to the HelpToSaveConnector" in new AuthorisedTestScenario with HelpToSaveMocking {
+      "return 200 with transactions obtained by passing NINO to the HelpToSaveConnector" in new AuthorisedTestScenario
+      with HelpToSaveMocking {
 
         helpToSaveGetTransactionsReturns(Future successful Right(transactionsSortedInHelpToSaveOrder))
 
@@ -76,7 +77,7 @@ class GetTransactionsSpec
         val resultF = controller.getTransactions(nino.value)(FakeRequest())
         status(resultF) shouldBe 404
         val jsonBody = contentAsJson(resultF)
-        (jsonBody \ "code").as[String] shouldBe "ACCOUNT_NOT_FOUND"
+        (jsonBody \ "code").as[String]    shouldBe "ACCOUNT_NOT_FOUND"
         (jsonBody \ "message").as[String] shouldBe "No Help to Save account exists for the specified NINO"
       }
     }
@@ -108,7 +109,7 @@ class GetTransactionsSpec
         val resultF = controller.getTransactions("invalidNino")(FakeRequest())
         status(resultF) shouldBe 400
         val jsonBody = contentAsJson(resultF)
-        (jsonBody \ "code").as[String] shouldBe "NINO_INVALID"
+        (jsonBody \ "code").as[String]    shouldBe "NINO_INVALID"
         (jsonBody \ "message").as[String] shouldBe """"invalidNino" does not match NINO validation regex"""
       }
     }
@@ -119,14 +120,14 @@ class GetTransactionsSpec
         val resultF = controller.getTransactions("AA 00 00 03 D")(FakeRequest())
         status(resultF) shouldBe 400
         val jsonBody = contentAsJson(resultF)
-        (jsonBody \ "code").as[String] shouldBe "NINO_INVALID"
+        (jsonBody \ "code").as[String]    shouldBe "NINO_INVALID"
         (jsonBody \ "message").as[String] shouldBe """"AA 00 00 03 D" does not match NINO validation regex"""
       }
     }
 
     "helpToSaveShuttered = true" should {
       """return 521 "shuttered": true""" in {
-        val accountService = mock[AccountService[Future]]
+        val accountService            = mock[AccountService[Future]]
         val helpToSaveGetTransactions = mock[HelpToSaveGetTransactions[Future]]
 
         val controller = new HelpToSaveController(
@@ -141,8 +142,8 @@ class GetTransactionsSpec
         status(resultF) shouldBe 521
         val jsonBody = contentAsJson(resultF)
         (jsonBody \ "shuttered").as[Boolean] shouldBe true
-        (jsonBody \ "title").as[String] shouldBe "Shuttered"
-        (jsonBody \ "message").as[String] shouldBe "HTS is currently not available"
+        (jsonBody \ "title").as[String]      shouldBe "Shuttered"
+        (jsonBody \ "message").as[String]    shouldBe "HTS is currently not available"
       }
     }
   }

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/SavingsGoalSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/SavingsGoalSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import uk.gov.hmrc.mobilehelptosave.{AccountTestData, TransactionTestData}
 
 //noinspection TypeAnnotation
 class SavingsGoalSpec
-  extends WordSpec
+    extends WordSpec
     with Matchers
     with SchemaMatchers
     with FutureAwaits
@@ -52,7 +52,8 @@ class SavingsGoalSpec
         status(resultF) shouldBe 204
       }
 
-      "translate a validation error to a 422 Unprocessable Entity" in new AuthorisedTestScenario with HelpToSaveMocking {
+      "translate a validation error to a 422 Unprocessable Entity" in new AuthorisedTestScenario
+      with HelpToSaveMocking {
         val amount  = mobileHelpToSaveAccount.maximumPaidInThisMonth.doubleValue() + 1
         val request = FakeRequest().withBody(SavingsGoal(amount))
 

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/TestSupport.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/helpToSave/TestSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,7 @@ import uk.gov.hmrc.mobilehelptosave.support.LoggerStub
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-case class TestHelpToSaveControllerConfig(shuttering: Shuttering)
-  extends HelpToSaveControllerConfig
+case class TestHelpToSaveControllerConfig(shuttering: Shuttering) extends HelpToSaveControllerConfig
 
 //noinspection TypeAnnotation
 trait TestSupport {
@@ -49,9 +48,10 @@ trait TestSupport {
   val config = TestHelpToSaveControllerConfig(falseShuttering)
 
   def isForbiddenIfNotAuthorisedForUser(authorisedActionForNino: HelpToSaveController => Assertion): Assertion = {
-    val accountService = mock[AccountService[Future]]
+    val accountService            = mock[AccountService[Future]]
     val helpToSaveGetTransactions = mock[HelpToSaveGetTransactions[Future]]
-    val controller = new HelpToSaveController(logger, accountService, helpToSaveGetTransactions, NeverAuthorisedWithIds, config)
+    val controller =
+      new HelpToSaveController(logger, accountService, helpToSaveGetTransactions, NeverAuthorisedWithIds, config)
     authorisedActionForNino(controller)
   }
 
@@ -72,28 +72,32 @@ trait TestSupport {
   trait HelpToSaveMocking {
     scenario: AuthorisedTestScenario =>
 
-    def accountReturns(stubbedResponse: Either[ErrorInfo, Option[Account]]) = {
-      (accountService.account(_: Nino)(_: HeaderCarrier))
+    def accountReturns(stubbedResponse: Either[ErrorInfo, Option[Account]]) =
+      (accountService
+        .account(_: Nino)(_: HeaderCarrier))
         .expects(nino, *)
         .returning(Future.successful(stubbedResponse))
-    }
 
-    def helpToSaveGetTransactionsReturns(stubbedResponse: Future[Either[ErrorInfo, Transactions]]) = {
-      (helpToSaveGetTransactions.getTransactions(_: Nino)(_: HeaderCarrier))
+    def helpToSaveGetTransactionsReturns(stubbedResponse: Future[Either[ErrorInfo, Transactions]]) =
+      (helpToSaveGetTransactions
+        .getTransactions(_: Nino)(_: HeaderCarrier))
         .expects(nino, *)
         .returning(stubbedResponse)
-    }
 
-    def setSavingsGoalReturns(expectedNino: Nino, expectedAmount: Double, stubbedResponse: Either[ErrorInfo, Unit]) = {
-      (accountService.setSavingsGoal(_: Nino, _: SavingsGoal)(_: HeaderCarrier))
-        .expects(where { (nino, amount, _) => nino == expectedNino && amount.goalAmount == expectedAmount })
+    def setSavingsGoalReturns(expectedNino: Nino, expectedAmount: Double, stubbedResponse: Either[ErrorInfo, Unit]) =
+      (accountService
+        .setSavingsGoal(_: Nino, _: SavingsGoal)(_: HeaderCarrier))
+        .expects(where { (nino, amount, _) =>
+          nino == expectedNino && amount.goalAmount == expectedAmount
+        })
         .returning(Future.successful(stubbedResponse))
-    }
 
-    def deleteSavingsGoalExpects(expectedNino: Nino) = {
-      (accountService.deleteSavingsGoal(_: Nino)(_: HeaderCarrier))
-        .expects(where { (suppliedNino: Nino, _) => suppliedNino == expectedNino })
+    def deleteSavingsGoalExpects(expectedNino: Nino) =
+      (accountService
+        .deleteSavingsGoal(_: Nino)(_: HeaderCarrier))
+        .expects(where { (suppliedNino: Nino, _) =>
+          suppliedNino == expectedNino
+        })
         .returning(Future.successful(().asRight))
-    }
   }
 }

--- a/test/uk/gov/hmrc/mobilehelptosave/domain/AccountJsonSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/domain/AccountJsonSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,21 +31,35 @@ class AccountJsonSpec extends WordSpec with Matchers with SchemaMatchers {
       .as[SchemaType]
 
   private val testAccount = Account(
-    number = "2000000000001",
+    number          = "2000000000001",
     openedYearMonth = new YearMonth(2018, 5),
-    isClosed = false,
+    isClosed        = false,
     Blocking(false),
     BigDecimal("543.12"),
-    0, 0, 0,
-    thisMonthEndDate = new LocalDate(2020, 12, 31),
+    0,
+    0,
+    0,
+    thisMonthEndDate          = new LocalDate(2020, 12, 31),
     nextPaymentMonthStartDate = Some(new LocalDate(2021, 1, 1)),
-    accountHolderName = "Testfore Testsur",
-    accountHolderEmail = Some("testemail@example.com"),
+    accountHolderName         = "Testfore Testsur",
+    accountHolderEmail        = Some("testemail@example.com"),
     bonusTerms = Seq(
-      BonusTerm(bonusEstimate = BigDecimal("200.12"), bonusPaid = BigDecimal("200.12"), endDate = new LocalDate(2020, 4, 30), bonusPaidOnOrAfterDate = new LocalDate(2020, 5, 1), balanceMustBeMoreThanForBonus = 0),
-      BonusTerm(bonusEstimate = BigDecimal("71.44"), bonusPaid = 0, endDate = new LocalDate(2022, 4, 30), bonusPaidOnOrAfterDate = new LocalDate(2022, 5, 1), balanceMustBeMoreThanForBonus = BigDecimal("400.24"))
+      BonusTerm(
+        bonusEstimate                 = BigDecimal("200.12"),
+        bonusPaid                     = BigDecimal("200.12"),
+        endDate                       = new LocalDate(2020, 4, 30),
+        bonusPaidOnOrAfterDate        = new LocalDate(2020, 5, 1),
+        balanceMustBeMoreThanForBonus = 0
+      ),
+      BonusTerm(
+        bonusEstimate                 = BigDecimal("71.44"),
+        bonusPaid                     = 0,
+        endDate                       = new LocalDate(2022, 4, 30),
+        bonusPaidOnOrAfterDate        = new LocalDate(2022, 5, 1),
+        balanceMustBeMoreThanForBonus = BigDecimal("400.24")
+      )
     ),
-    currentBonusTerm = CurrentBonusTerm.First,
+    currentBonusTerm     = CurrentBonusTerm.First,
     inAppPaymentsEnabled = false,
     daysRemainingInMonth = 1
   )
@@ -67,10 +81,10 @@ class AccountJsonSpec extends WordSpec with Matchers with SchemaMatchers {
     "account is closed" should {
       "be a valid instance of the schema used in the RAML" in {
         val closedAccount = testAccount.copy(
-          isClosed = true,
-          closureDate = Some(new LocalDate(2020, 11, 5)),
+          isClosed       = true,
+          closureDate    = Some(new LocalDate(2020, 11, 5)),
           closingBalance = Some(BigDecimal("543.12")),
-          balance = 0,
+          balance        = 0,
           bonusTerms = Seq(
             testAccount.bonusTerms.head,
             testAccount.bonusTerms(1).copy(bonusEstimate = 0)
@@ -83,9 +97,12 @@ class AccountJsonSpec extends WordSpec with Matchers with SchemaMatchers {
 
   "Account JSON" should {
     "format currentBonusTerm as documented in the README" in {
-      (Json.toJson(testAccount.copy(currentBonusTerm = CurrentBonusTerm.First)) \ "currentBonusTerm").as[String] shouldBe "First"
-      (Json.toJson(testAccount.copy(currentBonusTerm = CurrentBonusTerm.Second)) \ "currentBonusTerm").as[String] shouldBe "Second"
-      (Json.toJson(testAccount.copy(currentBonusTerm = CurrentBonusTerm.AfterFinalTerm)) \ "currentBonusTerm").as[String] shouldBe "AfterFinalTerm"
+      (Json.toJson(testAccount.copy(currentBonusTerm = CurrentBonusTerm.First)) \ "currentBonusTerm")
+        .as[String] shouldBe "First"
+      (Json.toJson(testAccount.copy(currentBonusTerm = CurrentBonusTerm.Second)) \ "currentBonusTerm")
+        .as[String] shouldBe "Second"
+      (Json.toJson(testAccount.copy(currentBonusTerm = CurrentBonusTerm.AfterFinalTerm)) \ "currentBonusTerm")
+        .as[String] shouldBe "AfterFinalTerm"
     }
   }
 }

--- a/test/uk/gov/hmrc/mobilehelptosave/domain/AccountSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/domain/AccountSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,23 +23,27 @@ import uk.gov.hmrc.mobilehelptosave.AccountTestData
 import uk.gov.hmrc.mobilehelptosave.connectors.HelpToSaveBonusTerm
 import uk.gov.hmrc.mobilehelptosave.support.LoggerStub
 
-class AccountSpec extends WordSpec with Matchers
-  with AccountTestData
-  with MockFactory with OneInstancePerTest with LoggerStub {
+class AccountSpec
+    extends WordSpec
+    with Matchers
+    with AccountTestData
+    with MockFactory
+    with OneInstancePerTest
+    with LoggerStub {
 
   private val accountOpenedInJan2018 = helpToSaveAccount.copy(
     openedYearMonth = new YearMonth(2018, 1),
     bonusTerms = Seq(
       HelpToSaveBonusTerm(
-        bonusEstimate = BigDecimal("90.99"),
-        bonusPaid = BigDecimal("90.99"),
-        endDate = new LocalDate(2019, 12, 31),
+        bonusEstimate          = BigDecimal("90.99"),
+        bonusPaid              = BigDecimal("90.99"),
+        endDate                = new LocalDate(2019, 12, 31),
         bonusPaidOnOrAfterDate = new LocalDate(2020, 1, 1)
       ),
       HelpToSaveBonusTerm(
-        bonusEstimate = 12,
-        bonusPaid = 0,
-        endDate = new LocalDate(2021, 12, 31),
+        bonusEstimate          = 12,
+        bonusPaid              = 0,
+        endDate                = new LocalDate(2021, 12, 31),
         bonusPaidOnOrAfterDate = new LocalDate(2022, 1, 1)
       )
     )
@@ -127,21 +131,21 @@ class AccountSpec extends WordSpec with Matchers
         openedYearMonth = new YearMonth(2018, 1),
         bonusTerms = Seq(
           HelpToSaveBonusTerm(
-            bonusEstimate = BigDecimal("90.99"),
-            bonusPaid = BigDecimal("90.99"),
-            endDate = new LocalDate(2019, 12, 31),
+            bonusEstimate          = BigDecimal("90.99"),
+            bonusPaid              = BigDecimal("90.99"),
+            endDate                = new LocalDate(2019, 12, 31),
             bonusPaidOnOrAfterDate = new LocalDate(2020, 1, 1)
           ),
           HelpToSaveBonusTerm(
-            bonusEstimate = 12,
-            bonusPaid = 0,
-            endDate = new LocalDate(2021, 12, 31),
+            bonusEstimate          = 12,
+            bonusPaid              = 0,
+            endDate                = new LocalDate(2021, 12, 31),
             bonusPaidOnOrAfterDate = new LocalDate(2022, 1, 1)
           ),
           HelpToSaveBonusTerm(
-            bonusEstimate = 0,
-            bonusPaid = 0,
-            endDate = new LocalDate(2023, 12, 31),
+            bonusEstimate          = 0,
+            bonusPaid              = 0,
+            endDate                = new LocalDate(2023, 12, 31),
             bonusPaidOnOrAfterDate = new LocalDate(2024, 1, 1)
           )
         )
@@ -151,11 +155,12 @@ class AccountSpec extends WordSpec with Matchers
       account.bonusTerms.size shouldBe 2
       // check that the first 2 terms were retained
       account.bonusTerms.head.endDate shouldBe new LocalDate(2019, 12, 31)
-      account.bonusTerms(1).endDate shouldBe new LocalDate(2021, 12, 31)
+      account.bonusTerms(1).endDate   shouldBe new LocalDate(2021, 12, 31)
 
       // If we see this warning in production we should probably enhance it to include an identifier such as the NINO.
       // No identifier included so far because I think it's unlikely this warning will ever be triggered - if it does we can hopefully tie it to a NINO using the request ID field in Kibana.
-      (slf4jLoggerStub.warn(_: String)) verify "Account contained 3 bonus terms, which is more than the expected 2 - discarding all but the first 2 terms"
+      (slf4jLoggerStub
+        .warn(_: String)) verify "Account contained 3 bonus terms, which is more than the expected 2 - discarding all but the first 2 terms"
     }
   }
 }

--- a/test/uk/gov/hmrc/mobilehelptosave/domain/TransactionsJsonSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/domain/TransactionsJsonSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@ class TransactionsJsonSpec extends WordSpec with Matchers with SchemaMatchers wi
   "Transactions JSON" when {
     "there is a typical list of transactions" should {
       "be a valid instance of the schema used in the RAML" in {
-        Json.toJson(transactionsSortedInMobileHelpToSaveOrder) should validateAgainstSchema(strictRamlTransactionsSchema)
+        Json.toJson(transactionsSortedInMobileHelpToSaveOrder) should validateAgainstSchema(
+          strictRamlTransactionsSchema)
       }
     }
 

--- a/test/uk/gov/hmrc/mobilehelptosave/json/JodaYearMonthJsonSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/json/JodaYearMonthJsonSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,8 @@ class JodaYearMonthJsonSpec extends WordSpec with Matchers {
     }
 
     "reject badly formatted strings with an error.expected.jodayearmonth.format error" in {
-      JsString("not a yearmonth").validate[YearMonth] shouldBe JsError(ValidationError("error.expected.jodayearmonth.format"))
+      JsString("not a yearmonth").validate[YearMonth] shouldBe JsError(
+        ValidationError("error.expected.jodayearmonth.format"))
     }
   }
 }

--- a/test/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalEventTest.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalEventTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,14 +33,14 @@ class SavingsGoalEventTest extends FreeSpecLike with Matchers with GeneratorDriv
   val genNino: Gen[Nino] =
     for {
       prefix <- Gen.oneOf(Nino.validPrefixes)
-      num <- Gen.listOfN(6, Gen.numChar).map(_.mkString)
+      num    <- Gen.listOfN(6, Gen.numChar).map(_.mkString)
       suffix <- Gen.oneOf(Nino.validSuffixes)
     } yield Nino(s"$prefix$num$suffix")
 
   val genSetEvent: Gen[SavingsGoalSetEvent] = for {
-    nino <- genNino
+    nino   <- genNino
     amount <- arbDouble.arbitrary
-    date <- genDateTime
+    date   <- genDateTime
   } yield SavingsGoalSetEvent(nino, amount, date)
 
   val genDeleteEvent: Gen[SavingsGoalDeleteEvent] = for {

--- a/test/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalEventTypeTest.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/repository/SavingsGoalEventTypeTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/mobilehelptosave/scalatest/SchemaMatchersSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/scalatest/SchemaMatchersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import uk.gov.hmrc.mobilehelptosave.scalatest.SchemaMatchers.validateAgainstSche
 class SchemaMatchersSpec extends WordSpec with Matchers {
   private val accountSchema: SchemaType = loadResourceJson("test_schema.json").as[SchemaType]
   val goodJsonExampleResourceName = "valid_instance.json"
-  val badJsonExampleResourceName = "invalid_instance.json"
+  val badJsonExampleResourceName  = "invalid_instance.json"
 
   "validateAgainstSchema(resourceName) method returns Matcher" should {
     val matcher = validateAgainstSchema(accountSchema)
@@ -38,8 +38,8 @@ class SchemaMatchersSpec extends WordSpec with Matchers {
       val goodJson: JsValue = loadResourceJson(goodJsonExampleResourceName)
       val goodJsonResult = matcher(goodJson)
 
-      goodJsonResult.matches shouldBe true
-      goodJsonResult.failureMessage shouldBe "JSON was not valid against schema"
+      goodJsonResult.matches               shouldBe true
+      goodJsonResult.failureMessage        shouldBe "JSON was not valid against schema"
       goodJsonResult.negatedFailureMessage shouldBe "JSON was valid against schema"
     }
 
@@ -49,8 +49,8 @@ class SchemaMatchersSpec extends WordSpec with Matchers {
 
       badJsonResult.matches shouldBe false
       badJsonResult.failureMessage should (startWith("JSON was not valid against schema")
-                                           and include("Property line1 missing")
-                                           and include("Property line3 missing"))
+        and include("Property line1 missing")
+        and include("Property line3 missing"))
 
       badJsonResult.negatedFailureMessage shouldBe "JSON was valid against schema"
     }

--- a/test/uk/gov/hmrc/mobilehelptosave/services/AccountServiceSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/services/AccountServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import uk.gov.hmrc.mobilehelptosave.repository.{SavingsGoalDeleteEvent, SavingsG
 import uk.gov.hmrc.mobilehelptosave.support.{LoggerStub, TestF}
 
 class AccountServiceSpec
-  extends WordSpec
+    extends WordSpec
     with Matchers
     with GeneratorDrivenPropertyChecks
     with AccountTestData
@@ -48,10 +48,11 @@ class AccountServiceSpec
 
   "account" should {
     "convert the account from the help-to-save domain to the mobile-help-to-save domain" in {
-      val fakeEnrolmentStatus = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
-      val fakeGetAccount = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
+      val fakeEnrolmentStatus  = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
+      val fakeGetAccount       = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
       val savingsGoalEventRepo = fakeSavingsGoalEventsRepo(nino, Right(List()))
-      val service = new AccountServiceImpl[TestF](logger, testConfig, fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
+      val service =
+        new AccountServiceImpl[TestF](logger, testConfig, fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
 
       // Because the service uses the system time to calculate the number of remaining days we need to adjust that in the result
       val result = service.account(nino).unsafeGet.map(_.map(_.copy(daysRemainingInMonth = 1)))
@@ -59,13 +60,14 @@ class AccountServiceSpec
     }
 
     "fold the value of the 'savingsGoalEnabled' config into the returned account" in {
-      val fakeEnrolmentStatus = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
-      val fakeGetAccount = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
+      val fakeEnrolmentStatus  = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
+      val fakeGetAccount       = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
       val savingsGoalEventRepo = fakeSavingsGoalEventsRepo(nino, Right(List()))
 
       forAll { enabled: Boolean =>
         val config = testConfig.copy(savingsGoalsEnabled = enabled)
-        val service = new AccountServiceImpl[TestF](logger, config, fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
+        val service =
+          new AccountServiceImpl[TestF](logger, config, fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
 
         // Because the service uses the system time to calculate the number of remaining days we need to adjust that in the result
         val result = service.account(nino).unsafeGet.map(_.map(_.copy(daysRemainingInMonth = 1)))
@@ -74,98 +76,124 @@ class AccountServiceSpec
     }
 
     "allow inAppPaymentsEnabled to be overridden with configuration" in {
-      val fakeEnrolmentStatus = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
-      val fakeGetAccount = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
+      val fakeEnrolmentStatus  = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
+      val fakeGetAccount       = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
       val savingsGoalEventRepo = fakeSavingsGoalEventsRepo(nino, Right(List()))
-      val service = new AccountServiceImpl[TestF](logger, testConfig.copy(inAppPaymentsEnabled = true), fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
+      val service = new AccountServiceImpl[TestF](
+        logger,
+        testConfig.copy(inAppPaymentsEnabled = true),
+        fakeEnrolmentStatus,
+        fakeGetAccount,
+        savingsGoalEventRepo)
 
       // Because the service uses the system time to calculate the number of remaining days we need to adjust that in the result
       val result = service.account(nino).unsafeGet.map(_.map(_.copy(daysRemainingInMonth = 1)))
-      result shouldBe Right(Some(mobileHelpToSaveAccount.copy(inAppPaymentsEnabled = true, savingsGoalsEnabled = testConfig.savingsGoalsEnabled)))
+      result shouldBe Right(
+        Some(mobileHelpToSaveAccount
+          .copy(inAppPaymentsEnabled = true, savingsGoalsEnabled = testConfig.savingsGoalsEnabled)))
     }
 
     // this is to avoid unnecessary load on NS&I, see NGC-3799
     "return None without attempting to get account from help-to-save when the user is not enrolled" in {
-      val fakeEnrolmentStatus = fakeHelpToSaveEnrolmentStatus(nino, Right(false))
+      val fakeEnrolmentStatus  = fakeHelpToSaveEnrolmentStatus(nino, Right(false))
       val savingsGoalEventRepo = fakeSavingsGoalEventsRepo(nino, Right(List()))
-      val service = new AccountServiceImpl[TestF](logger, testConfig, fakeEnrolmentStatus, ShouldNotBeCalledGetAccount, savingsGoalEventRepo)
+      val service = new AccountServiceImpl[TestF](
+        logger,
+        testConfig,
+        fakeEnrolmentStatus,
+        ShouldNotBeCalledGetAccount,
+        savingsGoalEventRepo)
       service.account(nino).unsafeGet shouldBe Right(None)
 
-      (slf4jLoggerStub.warn(_: String)) verify * never()
+      (slf4jLoggerStub.warn(_: String)) verify * never ()
     }
 
     "return None and log a warning when user is enrolled according to help-to-save but no account exists in NS&I" in {
-      val fakeEnrolmentStatus = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
-      val fakeGetAccount = fakeHelpToSaveGetAccount(nino, Right(None))
+      val fakeEnrolmentStatus  = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
+      val fakeGetAccount       = fakeHelpToSaveGetAccount(nino, Right(None))
       val savingsGoalEventRepo = fakeSavingsGoalEventsRepo(nino, Right(List()))
-      val service = new AccountServiceImpl[TestF](logger, testConfig, fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
+      val service =
+        new AccountServiceImpl[TestF](logger, testConfig, fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
 
       service.account(nino).unsafeGet shouldBe Right(None)
 
-      (slf4jLoggerStub.warn(_: String)) verify s"${nino.value} was enrolled according to help-to-save microservice but no account was found in NS&I - data is inconsistent"
+      (slf4jLoggerStub
+        .warn(_: String)) verify s"${nino.value} was enrolled according to help-to-save microservice but no account was found in NS&I - data is inconsistent"
     }
 
     "not call either fetchSavingsGoal or fetchNSAndIAccount if the user isn't enrolled" in {
       val fakeEnrolmentStatus = fakeHelpToSaveEnrolmentStatus(nino, Right(false))
 
       val fakeGetAccount = new HelpToSaveGetAccount[TestF] {
-        override def getAccount(nino: Nino)(implicit hc: HeaderCarrier): TestF[Either[ErrorInfo, Option[HelpToSaveAccount]]] =
+        override def getAccount(nino: Nino)(
+          implicit hc:                HeaderCarrier): TestF[Either[ErrorInfo, Option[HelpToSaveAccount]]] =
           fail("getAccount should not have been called")
       }
 
       val savingsGoalEventRepo = fakeSavingsGoalEventsRepo(nino, Right(List()))
 
-      val service = new AccountServiceImpl[TestF](logger, testConfig, fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
+      val service =
+        new AccountServiceImpl[TestF](logger, testConfig, fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
 
       service.account(nino).unsafeGet shouldBe Right(None)
     }
 
     "return errors returned by connector.enrolmentStatus" in {
-      val fakeEnrolmentStatus = fakeHelpToSaveEnrolmentStatus(nino, Left(ErrorInfo.General))
-      val fakeGetAccount = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
+      val fakeEnrolmentStatus  = fakeHelpToSaveEnrolmentStatus(nino, Left(ErrorInfo.General))
+      val fakeGetAccount       = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
       val savingsGoalEventRepo = fakeSavingsGoalEventsRepo(nino, Right(List()))
-      val service = new AccountServiceImpl[TestF](logger, testConfig, fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
+      val service =
+        new AccountServiceImpl[TestF](logger, testConfig, fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
       service.account(nino).unsafeGet shouldBe Left(ErrorInfo.General)
     }
 
     "return errors returned by connector.getAccount" in {
-      val fakeEnrolmentStatus = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
-      val fakeGetAccount = fakeHelpToSaveGetAccount(nino, Left(ErrorInfo.General))
+      val fakeEnrolmentStatus  = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
+      val fakeGetAccount       = fakeHelpToSaveGetAccount(nino, Left(ErrorInfo.General))
       val savingsGoalEventRepo = fakeSavingsGoalEventsRepo(nino, Right(List()))
-      val service = new AccountServiceImpl[TestF](logger, testConfig, fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
+      val service =
+        new AccountServiceImpl[TestF](logger, testConfig, fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
       service.account(nino).unsafeGet shouldBe Left(ErrorInfo.General)
     }
 
     "return errors if savingsGoalRepo.get throws exception" in {
-      val fakeEnrolmentStatus = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
-      val fakeGetAccount = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
+      val fakeEnrolmentStatus  = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
+      val fakeGetAccount       = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
       val savingsGoalEventRepo = fakeSavingsGoalEventsRepo(nino, Left(new Exception("test exception")))
-      val service = new AccountServiceImpl[TestF](logger, testConfig, fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
+      val service =
+        new AccountServiceImpl[TestF](logger, testConfig, fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
       service.account(nino).unsafeGet shouldBe Left(ErrorInfo.General)
     }
   }
 
-  private def fakeHelpToSaveEnrolmentStatus(expectedNino: Nino, enrolledOrError: Either[ErrorInfo, Boolean]): HelpToSaveEnrolmentStatus[TestF] =
+  private def fakeHelpToSaveEnrolmentStatus(
+    expectedNino:    Nino,
+    enrolledOrError: Either[ErrorInfo, Boolean]): HelpToSaveEnrolmentStatus[TestF] =
     new HelpToSaveEnrolmentStatus[TestF] {
       override def enrolmentStatus()(implicit hc: HeaderCarrier): TestF[Either[ErrorInfo, Boolean]] = {
         nino shouldBe expectedNino
-        hc shouldBe passedHc
+        hc   shouldBe passedHc
 
         F.pure(enrolledOrError)
       }
     }
 
-  private def fakeHelpToSaveGetAccount(expectedNino: Nino, accountOrError: Either[ErrorInfo, Option[HelpToSaveAccount]]): HelpToSaveGetAccount[TestF] =
+  private def fakeHelpToSaveGetAccount(
+    expectedNino:   Nino,
+    accountOrError: Either[ErrorInfo, Option[HelpToSaveAccount]]): HelpToSaveGetAccount[TestF] =
     new HelpToSaveGetAccount[TestF] {
-      override def getAccount(nino: Nino)(implicit hc: HeaderCarrier): TestF[Either[ErrorInfo, Option[HelpToSaveAccount]]] = {
+      override def getAccount(nino: Nino)(
+        implicit hc:                HeaderCarrier): TestF[Either[ErrorInfo, Option[HelpToSaveAccount]]] = {
         nino shouldBe expectedNino
-        hc shouldBe passedHc
+        hc   shouldBe passedHc
 
         F.pure(accountOrError)
       }
     }
 
-  private def fakeSavingsGoalEventsRepo(expectedNino: Nino, goalsOrException: Either[Throwable, List[SavingsGoalEvent]]): SavingsGoalEventRepo[TestF] =
+  private def fakeSavingsGoalEventsRepo(
+    expectedNino:     Nino,
+    goalsOrException: Either[Throwable, List[SavingsGoalEvent]]): SavingsGoalEventRepo[TestF] =
     new SavingsGoalEventRepo[TestF] {
       override def setGoal(nino: Nino, amount: Double): TestF[Unit] = {
         nino shouldBe expectedNino
@@ -188,21 +216,21 @@ class AccountServiceSpec
       override def clearGoalEvents(): TestF[Boolean] = F.pure(true)
       override def getGoal(nino: Nino): TestF[Option[SavingsGoal]] =
         goalsOrException match {
-          case Right(events) => F.pure {
-            events.sortBy(_.date)(localDateTimeOrdering.reverse).headOption.flatMap {
-              case _: SavingsGoalDeleteEvent         => None
-              case SavingsGoalSetEvent(_, amount, _) => Some(SavingsGoal(amount))
+          case Right(events) =>
+            F.pure {
+              events.sortBy(_.date)(localDateTimeOrdering.reverse).headOption.flatMap {
+                case _: SavingsGoalDeleteEvent => None
+                case SavingsGoalSetEvent(_, amount, _) => Some(SavingsGoal(amount))
+              }
             }
-          }
-          case Left(t)       => F.raiseError(t)
+          case Left(t) => F.raiseError(t)
         }
     }
 
   object ShouldNotBeCalledGetAccount extends HelpToSaveGetAccount[TestF] {
-    override def getAccount(nino: Nino)(implicit hc: HeaderCarrier): TestF[Either[ErrorInfo, Option[HelpToSaveAccount]]] = {
-      new RuntimeException("HelpToSaveGetAccount.getAccount should not be called in this situation").raiseError[TestF, Either[ErrorInfo, Option[HelpToSaveAccount]]]
-    }
+    override def getAccount(nino: Nino)(
+      implicit hc:                HeaderCarrier): TestF[Either[ErrorInfo, Option[HelpToSaveAccount]]] =
+      new RuntimeException("HelpToSaveGetAccount.getAccount should not be called in this situation")
+        .raiseError[TestF, Either[ErrorInfo, Option[HelpToSaveAccount]]]
   }
 }
-
-

--- a/test/uk/gov/hmrc/mobilehelptosave/services/ProdUserServiceSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/services/ProdUserServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,13 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class ProdUserServiceSpec
-  extends WordSpec with Matchers
-    with FutureAwaits with DefaultAwaitTimeout
-    with MockFactory with OneInstancePerTest with LoggerStub
+    extends WordSpec
+    with Matchers
+    with FutureAwaits
+    with DefaultAwaitTimeout
+    with MockFactory
+    with OneInstancePerTest
+    with LoggerStub
     with EitherValues {
 
   private implicit val passedHc: HeaderCarrier = HeaderCarrier()
@@ -39,13 +43,12 @@ class ProdUserServiceSpec
   private val generator = new Generator(0)
   private val nino      = generator.nextNino
 
-
   private class ProdUserServiceWithTestDefaults(
     helpToSaveConnector: HelpToSaveEnrolmentStatus[Future]
   ) extends ProdUserService(
-    logger,
-    helpToSaveConnector
-  )
+        logger,
+        helpToSaveConnector
+      )
 
   "userDetails" should {
     "return state=Enrolled when the current user is enrolled in Help to Save" in {
@@ -78,10 +81,10 @@ class ProdUserServiceSpec
 
   private def fakeHelpToSaveConnector(userIsEnrolledInHelpToSave: Either[ErrorInfo, Boolean]) =
     new HelpToSaveEnrolmentStatus[Future] {
-    override def enrolmentStatus()(implicit hc: HeaderCarrier): Future[Either[ErrorInfo, Boolean]] = {
-      hc shouldBe passedHc
+      override def enrolmentStatus()(implicit hc: HeaderCarrier): Future[Either[ErrorInfo, Boolean]] = {
+        hc shouldBe passedHc
 
-      Future successful userIsEnrolledInHelpToSave
+        Future successful userIsEnrolledInHelpToSave
+      }
     }
-  }
 }

--- a/test/uk/gov/hmrc/mobilehelptosave/services/SetSavingsGoalSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/services/SetSavingsGoalSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import uk.gov.hmrc.mobilehelptosave.repository.{SavingsGoalEvent, SavingsGoalEve
 import uk.gov.hmrc.mobilehelptosave.support.{LoggerStub, TestF}
 
 class SetSavingsGoalSpec
-  extends WordSpec
+    extends WordSpec
     with Matchers
     with GeneratorDrivenPropertyChecks
     with TestF
@@ -47,71 +47,105 @@ class SetSavingsGoalSpec
 
   "setSavingsGoal" should {
     "return Right[Unit] if successful" in {
-      val fakeEnrolmentStatus = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
-      val fakeGetAccount = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
+      val fakeEnrolmentStatus  = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
+      val fakeGetAccount       = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
       val savingsGoalEventRepo = fakeSavingsGoalEventsRepo(nino)
 
-      val service = new AccountServiceImpl[TestF](logger, testConfig.copy(inAppPaymentsEnabled = true), fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
+      val service = new AccountServiceImpl[TestF](
+        logger,
+        testConfig.copy(inAppPaymentsEnabled = true),
+        fakeEnrolmentStatus,
+        fakeGetAccount,
+        savingsGoalEventRepo)
 
       service.setSavingsGoal(nino, SavingsGoal(1.0)).unsafeGet shouldBe Right(())
     }
 
     "return a ValidationError if the goal is < 1.0" in {
-      val fakeEnrolmentStatus = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
-      val fakeGetAccount = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
+      val fakeEnrolmentStatus  = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
+      val fakeGetAccount       = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
       val savingsGoalEventRepo = fakeSavingsGoalEventsRepo(nino)
 
-      val service = new AccountServiceImpl[TestF](logger, testConfig.copy(inAppPaymentsEnabled = true), fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
+      val service = new AccountServiceImpl[TestF](
+        logger,
+        testConfig.copy(inAppPaymentsEnabled = true),
+        fakeEnrolmentStatus,
+        fakeGetAccount,
+        savingsGoalEventRepo)
 
       service.setSavingsGoal(nino, SavingsGoal(0.99)).unsafeGet.left.value shouldBe a[ErrorInfo.ValidationError]
     }
 
     "return a ValidationError if the goal is > maximum for month" in {
-      val fakeEnrolmentStatus = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
-      val fakeGetAccount = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
+      val fakeEnrolmentStatus  = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
+      val fakeGetAccount       = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
       val savingsGoalEventRepo = fakeSavingsGoalEventsRepo(nino)
 
-      val service = new AccountServiceImpl[TestF](logger, testConfig.copy(inAppPaymentsEnabled = true), fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
+      val service = new AccountServiceImpl[TestF](
+        logger,
+        testConfig.copy(inAppPaymentsEnabled = true),
+        fakeEnrolmentStatus,
+        fakeGetAccount,
+        savingsGoalEventRepo)
 
-      service.setSavingsGoal(nino, SavingsGoal(helpToSaveAccount.maximumPaidInThisMonth.toDouble + 0.01)).unsafeGet.left.value shouldBe a[ErrorInfo.ValidationError]
+      service
+        .setSavingsGoal(nino, SavingsGoal(helpToSaveAccount.maximumPaidInThisMonth.toDouble + 0.01))
+        .unsafeGet
+        .left
+        .value shouldBe a[ErrorInfo.ValidationError]
     }
 
     "return an AccountNotFound if the nino does not have an account with NS&I" in {
-      val fakeEnrolmentStatus = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
-      val fakeGetAccount = fakeHelpToSaveGetAccount(nino, Right(None))
+      val fakeEnrolmentStatus  = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
+      val fakeGetAccount       = fakeHelpToSaveGetAccount(nino, Right(None))
       val savingsGoalEventRepo = fakeSavingsGoalEventsRepo(nino)
 
-      val service = new AccountServiceImpl[TestF](logger, testConfig.copy(inAppPaymentsEnabled = true), fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
+      val service = new AccountServiceImpl[TestF](
+        logger,
+        testConfig.copy(inAppPaymentsEnabled = true),
+        fakeEnrolmentStatus,
+        fakeGetAccount,
+        savingsGoalEventRepo)
 
       service.setSavingsGoal(nino, SavingsGoal(1.0)).unsafeGet.left.value shouldBe ErrorInfo.AccountNotFound
     }
 
     "return a General error if the repo throws a Non-Fatal exception" in {
-      val fakeEnrolmentStatus = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
-      val fakeGetAccount = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
+      val fakeEnrolmentStatus  = fakeHelpToSaveEnrolmentStatus(nino, Right(true))
+      val fakeGetAccount       = fakeHelpToSaveGetAccount(nino, Right(Some(helpToSaveAccount)))
       val savingsGoalEventRepo = fakeSavingsGoalEventsRepo(nino, setGoalResponse = Left(new Exception("non fatal")))
 
-      val service = new AccountServiceImpl[TestF](logger, testConfig.copy(inAppPaymentsEnabled = true), fakeEnrolmentStatus, fakeGetAccount, savingsGoalEventRepo)
+      val service = new AccountServiceImpl[TestF](
+        logger,
+        testConfig.copy(inAppPaymentsEnabled = true),
+        fakeEnrolmentStatus,
+        fakeGetAccount,
+        savingsGoalEventRepo)
 
       service.setSavingsGoal(nino, SavingsGoal(1.0)).unsafeGet.left.value shouldBe ErrorInfo.General
     }
   }
 
-  private def fakeHelpToSaveEnrolmentStatus(expectedNino: Nino, enrolledOrError: Either[ErrorInfo, Boolean]): HelpToSaveEnrolmentStatus[TestF] =
+  private def fakeHelpToSaveEnrolmentStatus(
+    expectedNino:    Nino,
+    enrolledOrError: Either[ErrorInfo, Boolean]): HelpToSaveEnrolmentStatus[TestF] =
     new HelpToSaveEnrolmentStatus[TestF] {
       override def enrolmentStatus()(implicit hc: HeaderCarrier): TestF[Either[ErrorInfo, Boolean]] = {
         nino shouldBe expectedNino
-        hc shouldBe passedHc
+        hc   shouldBe passedHc
 
         F.pure(enrolledOrError)
       }
     }
 
-  private def fakeHelpToSaveGetAccount(expectedNino: Nino, accountOrError: Either[ErrorInfo, Option[HelpToSaveAccount]]): HelpToSaveGetAccount[TestF] =
+  private def fakeHelpToSaveGetAccount(
+    expectedNino:   Nino,
+    accountOrError: Either[ErrorInfo, Option[HelpToSaveAccount]]): HelpToSaveGetAccount[TestF] =
     new HelpToSaveGetAccount[TestF] {
-      override def getAccount(nino: Nino)(implicit hc: HeaderCarrier): TestF[Either[ErrorInfo, Option[HelpToSaveAccount]]] = {
+      override def getAccount(nino: Nino)(
+        implicit hc:                HeaderCarrier): TestF[Either[ErrorInfo, Option[HelpToSaveAccount]]] = {
         nino shouldBe expectedNino
-        hc shouldBe passedHc
+        hc   shouldBe passedHc
 
         F.pure(accountOrError)
       }
@@ -120,9 +154,9 @@ class SetSavingsGoalSpec
   private val fUnit = F.unit
 
   private def fakeSavingsGoalEventsRepo(
-    expectedNino: Nino,
-    goalsOrException: Either[Throwable, List[SavingsGoalEvent]] = List().asRight,
-    setGoalResponse: Either[Throwable, Unit] = ().asRight,
+    expectedNino:       Nino,
+    goalsOrException:   Either[Throwable, List[SavingsGoalEvent]] = List().asRight,
+    setGoalResponse:    Either[Throwable, Unit] = ().asRight,
     deleteGoalResponse: Either[Throwable, Unit] = ().asRight
   ): SavingsGoalEventRepo[TestF] = new SavingsGoalEventRepo[TestF] {
     override def setGoal(nino: Nino, amount: Double): TestF[Unit] = {
@@ -154,8 +188,8 @@ class SetSavingsGoalSpec
   }
 
   object ShouldNotBeCalledGetAccount extends HelpToSaveGetAccount[TestF] {
-    override def getAccount(nino: Nino)(implicit hc: HeaderCarrier): TestF[Either[ErrorInfo, Option[HelpToSaveAccount]]] = {
+    override def getAccount(nino: Nino)(
+      implicit hc:                HeaderCarrier): TestF[Either[ErrorInfo, Option[HelpToSaveAccount]]] =
       F.raiseError(new RuntimeException("HelpToSaveGetAccount.getAccount should not be called in this situation"))
-    }
   }
 }

--- a/test/uk/gov/hmrc/mobilehelptosave/services/TestAccountServiceConfig.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/services/TestAccountServiceConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,4 +18,5 @@ package uk.gov.hmrc.mobilehelptosave.services
 
 import uk.gov.hmrc.mobilehelptosave.config.AccountServiceConfig
 
-case class TestAccountServiceConfig(inAppPaymentsEnabled: Boolean, savingsGoalsEnabled: Boolean) extends AccountServiceConfig
+case class TestAccountServiceConfig(inAppPaymentsEnabled: Boolean, savingsGoalsEnabled: Boolean)
+    extends AccountServiceConfig

--- a/test/uk/gov/hmrc/mobilehelptosave/support/FakeHttpGet.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/support/FakeHttpGet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,25 +23,20 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpResponse}
 import scala.concurrent.Future
 
 class FakeHttpGet(urlPredicate: String => Boolean, responseF: Future[HttpResponse]) extends HttpGet {
-
   override def doGet(url: String)(implicit hc: HeaderCarrier): Future[HttpResponse] =
     if (urlPredicate(url))
       responseF
-  else
+    else
       Future successful HttpResponse(404)
 
   override def configuration: Option[Config] = None
-
-  override val hooks: Seq[HttpHook] = Seq.empty
-
+  override val hooks:         Seq[HttpHook]  = Seq.empty
 }
 
 object FakeHttpGet {
-
   def apply(expectedUrl: String, responseF: Future[HttpResponse]) = new FakeHttpGet(_ == expectedUrl, responseF)
-  def apply(expectedUrl: String, response: HttpResponse) = new FakeHttpGet(_ == expectedUrl, Future successful response)
+  def apply(expectedUrl: String, response:  HttpResponse)         = new FakeHttpGet(_ == expectedUrl, Future successful response)
 
   def apply(urlPredicate: String => Boolean, responseF: Future[HttpResponse]) = new FakeHttpGet(urlPredicate, responseF)
-  def apply(urlPredicate: String => Boolean, response: HttpResponse) = new FakeHttpGet(urlPredicate, Future successful response)
-
+  def apply(urlPredicate: String => Boolean, response:  HttpResponse)         = new FakeHttpGet(urlPredicate, Future successful response)
 }

--- a/test/uk/gov/hmrc/mobilehelptosave/support/FakeHttpGetSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/support/FakeHttpGetSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/mobilehelptosave/support/LoggerStub.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/support/LoggerStub.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/mobilehelptosave/support/TestF.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/support/TestF.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 package uk.gov.hmrc.mobilehelptosave.support
 
 import cats.MonadError
+import cats.instances.try_._
 
 import scala.util.Try
-import cats.instances.try_._
 
 /**
   * Defines a type constructor that can be used in tests to instantiate components that have a type constructor

--- a/test/uk/gov/hmrc/mobilehelptosave/support/ThrowableWithMessageContaining.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/support/ThrowableWithMessageContaining.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testcommon/uk/gov/hmrc/mobilehelptosave/AccountTestData.scala
+++ b/testcommon/uk/gov/hmrc/mobilehelptosave/AccountTestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testcommon/uk/gov/hmrc/mobilehelptosave/NumberVerification.scala
+++ b/testcommon/uk/gov/hmrc/mobilehelptosave/NumberVerification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testcommon/uk/gov/hmrc/mobilehelptosave/TransactionTestData.scala
+++ b/testcommon/uk/gov/hmrc/mobilehelptosave/TransactionTestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testcommon/uk/gov/hmrc/mobilehelptosave/io/Resources.scala
+++ b/testcommon/uk/gov/hmrc/mobilehelptosave/io/Resources.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testcommon/uk/gov/hmrc/mobilehelptosave/json/JsonResource.scala
+++ b/testcommon/uk/gov/hmrc/mobilehelptosave/json/JsonResource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testcommon/uk/gov/hmrc/mobilehelptosave/json/Schema.scala
+++ b/testcommon/uk/gov/hmrc/mobilehelptosave/json/Schema.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testcommon/uk/gov/hmrc/mobilehelptosave/raml/TransactionsSchema.scala
+++ b/testcommon/uk/gov/hmrc/mobilehelptosave/raml/TransactionsSchema.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testcommon/uk/gov/hmrc/mobilehelptosave/scalatest/SchemaMatchers.scala
+++ b/testcommon/uk/gov/hmrc/mobilehelptosave/scalatest/SchemaMatchers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testcommon/uk/gov/hmrc/mobilehelptosave/services/FakeClock.scala
+++ b/testcommon/uk/gov/hmrc/mobilehelptosave/services/FakeClock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
I've added a `.scalafmt.conf` file, based on the file from `http-verbs`, and re-formatted the code. The headers plugin has updated the copyright year to 2019 in all files.

I've also disabled `-Ywarn-unused-import` and enabled `-Xfatal-warnings` and fixed up the return types in the it test wiremock stub generators to not warn about discarded non-unit values. We can't have both `-Ywarn-unused-import` and `-Xfatal-warnings` enabled at the same time because of the unused imports in the source that Play creates for the routes. On balance, fatal-warnings is probably more useful to us.