### PR TITLE
[DC] Remove workaround `health2.routes`

### DIFF
--- a/app/uk/gov/hmrc/mobilehelptosave/wiring/ServiceComponents.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/wiring/ServiceComponents.scala
@@ -57,7 +57,7 @@ class ServiceComponents(context: Context)
   lazy val prefix:           String                           = "/"
   lazy val sandboxRouter:    sandbox.Routes                   = wire[sandbox.Routes]
   lazy val definitionRouter: definition.Routes                = wire[definition.Routes]
-  lazy val healthRouter:     health2.Routes                   = wire[health2.Routes]
+  lazy val healthRouter:     health.Routes                    = wire[health.Routes]
   lazy val appRouter:        app.Routes                       = wire[app.Routes]
   lazy val apiRouter:        api.Routes                       = wire[api.Routes]
   lazy val testRouter:       _root_.test.Routes               = wire[_root_.test.Routes]

--- a/conf/health2.routes
+++ b/conf/health2.routes
@@ -1,5 +1,0 @@
-# Routes
-# This file defines all application routes (Higher priority routes first)
-# ~~~~
-GET     /ping/ping       uk.gov.hmrc.play.health.HealthController.ping
-GET     /admin/details   uk.gov.hmrc.play.health.HealthController.details

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,7 +1,7 @@
 # Add all the application routes to the app.routes file
 ->    /mobile-help-to-save                app.Routes
 ->    /                                   api.Routes
-->    /                                   health2.Routes
+->    /                                   health.Routes
 ->    /                                   definition.Routes
 
 GET   /admin/metrics                     com.kenshoo.play.metrics.MetricsController.metrics

--- a/it/uk/gov/hmrc/mobilehelptosave/SandboxISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/SandboxISpec.scala
@@ -23,7 +23,6 @@ import play.api.libs.ws.WSResponse
 import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
 import uk.gov.hmrc.domain.Generator
 import uk.gov.hmrc.mobilehelptosave.domain.{Account, SavingsGoal, Transactions}
-import uk.gov.hmrc.mobilehelptosave.repository.SavingsGoalEvent
 import uk.gov.hmrc.mobilehelptosave.scalatest.SchemaMatchers
 import uk.gov.hmrc.mobilehelptosave.support.{OneServerPerSuiteWsClient, WireMockSupport}
 
@@ -54,9 +53,9 @@ class SandboxISpec
   "GET /savings-account/{nino} with sandbox header" should {
     "Return OK response containing valid Account JSON including a savings goal" in {
       val response: WSResponse = await(wsUrl(s"/savings-account/$nino").addHttpHeaders(sandboxRoutingHeader).get())
-      response.status                 shouldBe Status.OK
+      response.status shouldBe Status.OK
       val accountV = response.json.validate[Account]
-      accountV shouldBe 'success
+      accountV                                          shouldBe 'success
       accountV.asOpt.value.savingsGoal.value.goalAmount shouldBe 25.0
     }
   }
@@ -64,8 +63,8 @@ class SandboxISpec
   "PUT /savings-account/:nino/goals/current-goal with sandbox header" should {
     "Return a No Content response" in {
       val goal = SavingsGoal(35.0)
-      val response: WSResponse = await(
-        wsUrl(s"/savings-account/$nino/goals/current-goal").addHttpHeaders(sandboxRoutingHeader).put(Json.toJson(goal)))
+      val response: WSResponse =
+        await(wsUrl(s"/savings-account/$nino/goals/current-goal").addHttpHeaders(sandboxRoutingHeader).put(Json.toJson(goal)))
       response.status shouldBe Status.NO_CONTENT
     }
   }


### PR DESCRIPTION
When I originally did the static wiring for the components there was a problem with the version of the health routes from the play 2.5 version of the `play-health` library. Because it had been built with the static routes compiler, the `health.Routes` class was using the guice injector to wire things, which was not compatible with the static DI, so I added a `health2.routes` file that replicated the routes using the non-static routes compiler.

Now that we've upgraded to Play 2.6, we're using a version of `play-health` that has a non-statically-compiled routes file (i.e. `health.Routes` is now a class that takes its dependencies as parameters) so I have removed the work-around `health2.routes` file and updated the `prod.routes`.