### PR TITLE
[NGC-4762] I've added a new property `accountPayInUrl` to the startup…

### DIFF
--- a/app/uk/gov/hmrc/mobilehelptosave/config/MobileHelpToSaveConfig.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/config/MobileHelpToSaveConfig.scala
@@ -53,6 +53,7 @@ case class MobileHelpToSaveConfig(
   override val inAppPaymentsEnabled:       Boolean = configBoolean("helpToSave.inAppPaymentsEnabled")
   override val helpToSaveInfoUrl:          String  = configString("helpToSave.infoUrl")
   override val helpToSaveAccessAccountUrl: String  = configString("helpToSave.accessAccountUrl")
+  override val helpToSaveAccountPayInUrl:  String  = configString("helpToSave.accountPayInUrl")
 
   private val accessConfig = configuration.underlying.getConfig("api.access")
   override val apiAccessType:              String      = accessConfig.getString("type")
@@ -98,6 +99,7 @@ trait StartupControllerConfig {
   def supportFormEnabled:         Boolean
   def helpToSaveInfoUrl:          String
   def helpToSaveAccessAccountUrl: String
+  def helpToSaveAccountPayInUrl:  String
 }
 
 trait HelpToSaveControllerConfig {

--- a/app/uk/gov/hmrc/mobilehelptosave/controllers/StartupController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/controllers/StartupController.scala
@@ -40,6 +40,7 @@ class StartupController(
           shuttering         = config.shuttering,
           infoUrl            = Some(config.helpToSaveInfoUrl),
           accessAccountUrl   = Some(config.helpToSaveAccessAccountUrl),
+          accountPayInUrl    = Some(config.helpToSaveAccountPayInUrl),
           user               = userOrError.right.toOption,
           userError          = userOrError.left.toOption,
           supportFormEnabled = config.supportFormEnabled
@@ -54,6 +55,7 @@ class StartupController(
           shuttering         = config.shuttering,
           infoUrl            = None,
           accessAccountUrl   = None,
+          accountPayInUrl    = None,
           user               = None,
           userError          = None,
           supportFormEnabled = config.supportFormEnabled

--- a/app/uk/gov/hmrc/mobilehelptosave/domain/StartupResponse.scala
+++ b/app/uk/gov/hmrc/mobilehelptosave/domain/StartupResponse.scala
@@ -22,6 +22,7 @@ case class StartupResponse(
   shuttering:         Shuttering,
   infoUrl:            Option[String],
   accessAccountUrl:   Option[String],
+  accountPayInUrl:    Option[String],
   user:               Option[UserDetails],
   userError:          Option[ErrorInfo],
   supportFormEnabled: Boolean

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -59,16 +59,16 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-play.crypto.secret="vtMP3LbUX0XSG5Ucj56W2jETzOIim1wolee3iuaNMyZ6Qfc2kRC0Yw0pODT331NW"
+play.crypto.secret = "vtMP3LbUX0XSG5Ucj56W2jETzOIim1wolee3iuaNMyZ6Qfc2kRC0Yw0pODT331NW"
 
 # Session configuration
 # ~~~~~
-application.session.httpOnly=false
-application.session.secure=false
+application.session.httpOnly = false
+application.session.secure = false
 
 # The application languages
 # ~~~~~
-play.i18n.langs=["en"]
+play.i18n.langs = ["en"]
 
 # Router
 # ~~~~~
@@ -80,7 +80,7 @@ play.i18n.langs=["en"]
 # you may need to define a router file `conf/my.application.routes`.
 # Default to Routes in the root package (and conf/routes)
 # !!!WARNING!!! DO NOT CHANGE THIS ROUTER
-play.http.router=prod.Routes
+play.http.router = prod.Routes
 
 
 # Controller
@@ -188,6 +188,7 @@ helpToSave {
   savingsGoalsEnabled = false
   infoUrl = "https://www.gov.uk/get-help-savings-low-income"
   accessAccountUrl = "http://localhost:8249/mobile-help-to-save/access-account"
+  accountPayInUrl = "http://localhost:8249/mobile-help-to-save/pay-in"
   shuttering = {
     shuttered = false
     title = ""

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,9 +1,9 @@
 # Add all the application routes to the app.routes file
-->    /mobile-help-to-save                app.Routes
-->    /                                   api.Routes
-->    /                                   health.Routes
-->    /                                   definition.Routes
+->         /mobile-help-to-save        app.Routes
+->         /                           api.Routes
+->         /                           health.Routes
+->         /                           definition.Routes
 
-GET   /admin/metrics                     com.kenshoo.play.metrics.MetricsController.metrics
+GET        /admin/metrics              com.kenshoo.play.metrics.MetricsController.metrics
 
-->    /sandbox                            sandbox.Routes
+->         /sandbox                    sandbox.Routes

--- a/it/uk/gov/hmrc/mobilehelptosave/StartupConfigISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosave/StartupConfigISpec.scala
@@ -91,8 +91,8 @@ class StartupConfigISpec
       response.status                                          shouldBe 200
       (response.json \ "supportFormEnabled").validate[Boolean] should beJsSuccess
       (response.json \ "infoUrl").as[String]                   shouldBe "https://www.gov.uk/get-help-savings-low-income"
-      (response.json \ "accessAccountUrl")
-        .as[String] shouldBe "http://localhost:8249/mobile-help-to-save/access-account"
+      (response.json \ "accessAccountUrl").as[String]          shouldBe "http://localhost:8249/mobile-help-to-save/access-account"
+      (response.json \ "accountPayInUrl").as[String]           shouldBe "http://localhost:8249/mobile-help-to-save/pay-in"
     }
 
     "allow feature flag and URL settings to be overridden in configuration" in {
@@ -104,6 +104,7 @@ class StartupConfigISpec
           .configure(
             "helpToSave.infoUrl"            -> "http://www.example.com/test/help-to-save-information",
             "helpToSave.accessAccountUrl"   -> "/access-account",
+            "helpToSave.accountPayInUrl"    -> "/pay-in",
             "helpToSave.supportFormEnabled" -> "true"
           )
           .build()) { (app: Application, portNumber: PortNumber) =>
@@ -115,6 +116,7 @@ class StartupConfigISpec
         (response.json \ "supportFormEnabled").as[Boolean] shouldBe true
         (response.json \ "infoUrl").as[String]             shouldBe "http://www.example.com/test/help-to-save-information"
         (response.json \ "accessAccountUrl").as[String]    shouldBe "/access-account"
+        (response.json \ "accountPayInUrl").as[String]     shouldBe "/pay-in"
       }
 
       withTestServer(

--- a/test/uk/gov/hmrc/mobilehelptosave/controllers/StartupControllerSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosave/controllers/StartupControllerSpec.scala
@@ -46,7 +46,8 @@ class StartupControllerSpec extends WordSpec with Matchers with MockFactory with
     falseShuttering,
     supportFormEnabled         = false,
     helpToSaveInfoUrl          = "/info",
-    helpToSaveAccessAccountUrl = "/accessAccount"
+    helpToSaveAccessAccountUrl = "/accessAccount",
+    helpToSaveAccountPayInUrl  = "/payIn"
   )
 
   private val testUserDetails = UserDetails(UserState.NotEnrolled)
@@ -87,6 +88,7 @@ class StartupControllerSpec extends WordSpec with Matchers with MockFactory with
         jsonKeys                                   should contain("user")
         (jsonBody \ "infoUrl").as[String]          shouldBe "/info"
         (jsonBody \ "accessAccountUrl").as[String] shouldBe "/accessAccount"
+        (jsonBody \ "accountPayInUrl").as[String]    shouldBe "/payIn"
       }
 
       "include shuttering information in response with shuttered = false" in {
@@ -122,6 +124,7 @@ class StartupControllerSpec extends WordSpec with Matchers with MockFactory with
         (jsonBody \ "userError" \ "code").as[String] shouldBe "GENERAL"
         (jsonBody \ "infoUrl").as[String]            shouldBe "/info"
         (jsonBody \ "accessAccountUrl").as[String]   shouldBe "/accessAccount"
+        (jsonBody \ "accountPayInUrl").as[String]    shouldBe "/payIn"
       }
     }
 
@@ -140,6 +143,7 @@ class StartupControllerSpec extends WordSpec with Matchers with MockFactory with
         jsonKeys should not contain "user"
         jsonKeys should not contain "infoUrl"
         jsonKeys should not contain "accessAccountUrl"
+        jsonKeys should not contain "accountPayInUrl"
       }
 
       "include shuttering info in response" in {
@@ -185,5 +189,6 @@ case class TestStartupControllerConfig(
   shuttering:                 Shuttering,
   supportFormEnabled:         Boolean,
   helpToSaveInfoUrl:          String,
-  helpToSaveAccessAccountUrl: String
+  helpToSaveAccessAccountUrl: String,
+  helpToSaveAccountPayInUrl:  String
 ) extends StartupControllerConfig


### PR DESCRIPTION
… response. This is configured with the `mobile-help-to-save-frontend` endpoint that will redirect directly to the pay-in page on `help-to-save-frontend`.