### PR TITLE
API-4942 - Tweaked RAML title

### DIFF
--- a/resources/public/api/conf/1.0/application.raml
+++ b/resources/public/api/conf/1.0/application.raml
@@ -1,5 +1,5 @@
 #%RAML 1.0
-title: Help To Save
+title: Mobile Help To Save
 version: 1.0
 protocols: [ HTTPS ]
 baseUri: https://api.service.hmrc.gov.uk/


### PR DESCRIPTION
The mobile-help-to-save and help-to-same both have the title in the RAML defined as "Help to save". This is causing some confusion on the API Platform / API Catalogue where we're using the title, and it looks like we have two copies of the Help To Save API!

So this is to rename this one to include Mobile in the RAML title.